### PR TITLE
Fixes Issue with resource apim_mule4 creation.

### DIFF
--- a/anypoint/resource_apim_mule4.go
+++ b/anypoint/resource_apim_mule4.go
@@ -360,7 +360,6 @@ func newApimMule4PostBody(d *schema.ResourceData) *apim.ApimInstancePostBody {
 	}
 	body.SetTechnology(APIM_MULE4_TECHNOLOGY)
 	body.SetEndpoint(*endpoint)
-	body.SetDeploymentNil()
 	body.SetSpec(*spec)
 
 	return body


### PR DESCRIPTION
Following new validation rules added to the Anypoint API, removed nil deployment object from resource apim_mule4 creation body. 

Related Issue: #65 