### PR TITLE
Fix: Import Bad Parameters

### DIFF
--- a/anypoint/data_source_apim_instance.go
+++ b/anypoint/data_source_apim_instance.go
@@ -457,7 +457,10 @@ func readApimInstanceUpstreamsOnly(ctx context.Context, d *schema.ResourceData, 
 	envid := d.Get("env_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, id = decomposeApimFlexGatewayId(d)
+		orgid, envid, id, diags = decomposeApimFlexGatewayId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getApimUpstreamAuthCtx(ctx, &pco)
 	//perform request

--- a/anypoint/resource_ame.go
+++ b/anypoint/resource_ame.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -126,7 +127,10 @@ func resourceAMERead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	exchangeid := d.Get("exchange_id").(string)
 	id := d.Id()
 	if isComposedResourceId(id) {
-		orgid, envid, regionid, exchangeid = decomposeAMEId(d)
+		orgid, envid, regionid, exchangeid, diags = decomposeAMEId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getAMEAuthCtx(ctx, &pco)
 	//request resource
@@ -250,9 +254,18 @@ func newAMECreateBody(d *schema.ResourceData) *ame.ExchangeBody {
 	return body
 }
 
-func decomposeAMEId(d *schema.ResourceData, separator ...string) (string, string, string, string) {
+func decomposeAMEId(d *schema.ResourceData, separator ...string) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id(), separator...)
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid AME ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/REGION_ID/EXCHANGE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }
 
 /*

--- a/anypoint/resource_amq.go
+++ b/anypoint/resource_amq.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -160,7 +161,10 @@ func resourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	queueid := d.Get("queue_id").(string)
 	id := d.Id()
 	if isComposedResourceId(id) {
-		orgid, envid, regionid, queueid = decomposeAMQId(d)
+		orgid, envid, regionid, queueid, diags = decomposeAMQId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getAMQAuthCtx(ctx, &pco)
 	//request resource
@@ -316,9 +320,18 @@ func newAMQCreateBody(d *schema.ResourceData) *amq.QueueBody {
 	return body
 }
 
-func decomposeAMQId(d *schema.ResourceData, separator ...string) (string, string, string, string) {
+func decomposeAMQId(d *schema.ResourceData, separator ...string) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id(), separator...)
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid AMQ ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/REGION_ID/QUEUE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }
 
 /*

--- a/anypoint/resource_apim_policy_basic_auth.go
+++ b/anypoint/resource_apim_policy_basic_auth.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strconv"
 
@@ -203,7 +204,10 @@ func resourceApimInstancePolicyBasicAuthRead(ctx context.Context, d *schema.Reso
 	apimid := d.Get("apim_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, apimid, id = decomposeApimPolicyBasicAuthId(d)
+		orgid, envid, apimid, id, diags = decomposeApimPolicyBasicAuthId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	//perform request
@@ -447,7 +451,16 @@ func newApimPolicyBasicAuthPointcutDataBody(collection []any) []apim_policy.Poin
 	return slice
 }
 
-func decomposeApimPolicyBasicAuthId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeApimPolicyBasicAuthId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid APIM Policy Basic Auth ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/APIM_ID/INSTANCE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_apim_policy_client_id_enforcement.go
+++ b/anypoint/resource_apim_policy_client_id_enforcement.go
@@ -224,7 +224,10 @@ func resourceApimInstancePolicyClientIdEnfRead(ctx context.Context, d *schema.Re
 	apimid := d.Get("apim_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, apimid, id = decomposeApimPolicyClientIdEnfId(d)
+		orgid, envid, apimid, id, diags = decomposeApimPolicyClientIdEnfId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	//perform request
@@ -499,7 +502,16 @@ func validateClientIdEnfCfg(d *schema.ResourceDiff) error {
 	return nil
 }
 
-func decomposeApimPolicyClientIdEnfId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeApimPolicyClientIdEnfId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid APIM Policy Client ID Enforcement ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/APIM_ID/INSTANCE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_apim_policy_jwt_validation.go
+++ b/anypoint/resource_apim_policy_jwt_validation.go
@@ -439,7 +439,10 @@ func resourceApimInstancePolicyJwtValidationRead(ctx context.Context, d *schema.
 	apimid := d.Get("apim_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, apimid, id = decomposeApimPolicyJwtValidationId(d)
+		orgid, envid, apimid, id, diags = decomposeApimPolicyJwtValidationId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	//perform request
@@ -760,7 +763,16 @@ func getApimPolicyJwtValidationCfgAttributes() []string {
 	}
 }
 
-func decomposeApimPolicyJwtValidationId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeApimPolicyJwtValidationId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid APIM Policy JWT Validation ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/APIM_ID/INSTANCE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_apim_policy_message_logging.go
+++ b/anypoint/resource_apim_policy_message_logging.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"regexp"
 	"strconv"
@@ -257,7 +258,10 @@ func resourceApimInstancePolicyMessageLoggingRead(ctx context.Context, d *schema
 	apimid := d.Get("apim_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, apimid, id = decomposeApimPolicyMessageLoggingId(d)
+		orgid, envid, apimid, id, diags = decomposeApimPolicyMessageLoggingId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	//perform request
@@ -558,7 +562,16 @@ func newApimPolicyMessageLoggingPointcutDataBody(collection []any) []apim_policy
 	return slice
 }
 
-func decomposeApimPolicyMessageLoggingId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeApimPolicyMessageLoggingId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid APIM Policy Message Logging ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/APIM_ID/INSTANCE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_apim_policy_rate_limit.go
+++ b/anypoint/resource_apim_policy_rate_limit.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"maps"
 	"regexp"
@@ -243,7 +244,10 @@ func resourceApimInstancePolicyRateLimitingRead(ctx context.Context, d *schema.R
 	apimid := d.Get("apim_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, apimid, id = decomposeApimPolicyRateLimitingId(d)
+		orgid, envid, apimid, id, diags = decomposeApimPolicyRateLimitingId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	//perform request
@@ -542,7 +546,16 @@ func newApimPolicyRateLimitingPointcutDataBody(collection []any) []apim_policy.P
 	return slice
 }
 
-func decomposeApimPolicyRateLimitingId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeApimPolicyRateLimitingId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid APIM Policy Rate Limiting ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/APIM_ID/INSTANCE_ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_private_space_tlscontext_jks.go
+++ b/anypoint/resource_private_space_tlscontext_jks.go
@@ -250,7 +250,10 @@ func resourcePrivateSpaceTlsContextJKSRead(ctx context.Context, d *schema.Resour
 	authctx := getPrivateSpaceTlsContextAuthCtx(ctx, &pco)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, private_space_id, id = decomposePrivateSpaceTlsContextId(d)
+		orgid, private_space_id, id, diags = decomposePrivateSpaceTlsContextId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	//request
 	tlscontext, httpr, err := pco.privatespacetlscontextclient.DefaultApi.GetTlsContext(authctx, orgid, private_space_id, id).Execute()
@@ -331,9 +334,6 @@ func resourcePrivateSpaceTlsContextJKSDelete(ctx context.Context, d *schema.Reso
 	private_space_id := d.Get("private_space_id").(string)
 	authctx := getPrivateSpaceTlsContextAuthCtx(ctx, &pco)
 	id := d.Get("id").(string)
-	if isComposedResourceId(id) {
-		orgid, private_space_id, id = decomposePrivateSpaceTlsContextId(d)
-	}
 	//request
 	httpr, err := pco.privatespacetlscontextclient.DefaultApi.DeleteTlsContext(authctx, orgid, private_space_id, id).Execute()
 	if err != nil {

--- a/anypoint/resource_secretgroup_certificate.go
+++ b/anypoint/resource_secretgroup_certificate.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -162,7 +163,10 @@ func resourceSecretGroupCertificateRead(ctx context.Context, d *schema.ResourceD
 	sgid := d.Get("sg_id").(string)
 	id := d.Get("id").(string)
 	if isComposedResourceId(id) {
-		orgid, envid, sgid, id = decomposeSgCertificateId(d)
+		orgid, envid, sgid, id, diags = decomposeSgCertificateId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	authctx := getSgCertificateAuthCtx(ctx, &pco)
 	//perform request
@@ -300,9 +304,18 @@ func loadSgCertificatePutBody(req secretgroup_certificate.DefaultApiPutSecretGro
 }
 
 // returns the composed of the secret
-func decomposeSgCertificateId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeSgCertificateId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid Secret Group Certificate ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/SG_ID/ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }
 
 func getSgCertificateUpdatableAttributes() []string {

--- a/anypoint/resource_secretgroup_crldistrib_cfgs.go
+++ b/anypoint/resource_secretgroup_crldistrib_cfgs.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -146,7 +147,10 @@ func resourceSecretGroupCrlDistribCfgsRead(ctx context.Context, d *schema.Resour
 	id := d.Get("id").(string)
 	authctx := getSgCrlDistribCfgsAuthCtx(ctx, &pco)
 	if isComposedResourceId(id) {
-		orgid, envid, sgid, id = decomposeSgCrlDistribCfgsId(d)
+		orgid, envid, sgid, id, diags = decomposeSgCrlDistribCfgsId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	//perform request
 	res, httpr, err := pco.sgcrldistribcfgsclient.DefaultApi.GetSecretGroupCrlDistribCfgsDetails(authctx, orgid, envid, sgid, id).Execute()
@@ -275,7 +279,16 @@ func getSgCrlDistribCfgsAuthCtx(ctx context.Context, pco *ProviderConfOutput) co
 }
 
 // returns the composed of the secret
-func decomposeSgCrlDistribCfgsId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeSgCrlDistribCfgsId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid Secret Group CRL Distributor Configs ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/SG_ID/ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_secretgroup_tlscontext_flexgateway.go
+++ b/anypoint/resource_secretgroup_tlscontext_flexgateway.go
@@ -2,6 +2,7 @@ package anypoint
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -236,7 +237,10 @@ func resourceSecretGroupTlsContextFGRead(ctx context.Context, d *schema.Resource
 	id := d.Get("id").(string)
 	authctx := getSgTlsContextAuthCtx(ctx, &pco)
 	if isComposedResourceId(id) {
-		orgid, envid, sgid, id = decomposeSgTlsContextFGId(d)
+		orgid, envid, sgid, id, diags = decomposeSgTlsContextFGId(d)
+	}
+	if diags.HasError() {
+		return diags
 	}
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
@@ -402,7 +406,16 @@ func getSgTlsContextFGUpdatableAttributes() []string {
 }
 
 // returns the composed of the secret
-func decomposeSgTlsContextFGId(d *schema.ResourceData) (string, string, string, string) {
+func decomposeSgTlsContextFGId(d *schema.ResourceData) (string, string, string, string, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	s := DecomposeResourceId(d.Id())
-	return s[0], s[1], s[2], s[3]
+	if len(s) != 4 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid Secret Group TLS Context FlexGateway ID format",
+			Detail:   fmt.Sprintf("Expected ORG_ID/ENV_ID/SG_ID/ID, got %s", d.Id()),
+		})
+		return "", "", "", "", diags
+	}
+	return s[0], s[1], s[2], s[3], diags
 }

--- a/anypoint/resource_user_rolegroup.go
+++ b/anypoint/resource_user_rolegroup.go
@@ -143,9 +143,12 @@ func resourceUserRolegroupRead(ctx context.Context, d *schema.ResourceData, m an
 	rolegroupid := d.Get("rolegroup_id").(string)
 	id := d.Id()
 	if isComposedResourceId(id) {
-		orgid, userid, rolegroupid = decomposeUserRolegroupId(d)
+		orgid, userid, rolegroupid, diags = decomposeUserRolegroupId(d)
 	} else if isComposedResourceId(id, "_") { // retro-compatibility with versions < 1.6.x
-		orgid, userid, rolegroupid = decomposeUserRolegroupId(d, "_")
+		orgid, userid, rolegroupid, diags = decomposeUserRolegroupId(d, "_")
+	}
+	if diags.HasError() {
+		return diags
 	}
 	rg, errDiags := searchUserRolegroup(ctx, d, m)
 	if errDiags.HasError() {


### PR DESCRIPTION
When the user supplies bad parameters for import, the plugin would crash due to the wrong number of parameters.
This P.R adds control of composed id when supplied for import in order to enhance user experience.