### PR TITLE
Prepare v1.8.1 — IDP OIDC fixes (manual + dynamic client registration)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=anypoint.mulesoft.com
 NAMESPACE=automation
 NAME=anypoint
 BINARY=terraform-provider-${NAME}
-VERSION=1.7.1-SNAPSHOT
+VERSION=1.8.1-SNAPSHOT
 OS_ARCH=darwin_amd64
 
 default: install

--- a/anypoint/resource_idp_oidc.go
+++ b/anypoint/resource_idp_oidc.go
@@ -306,12 +306,11 @@ func newOIDCPostBody(d *schema.ResourceData) (*idp.IdpPostBody, diag.Diagnostics
 	oidc_provider_data := oidc_provider_input[0].(map[string]any)
 
 	// in case we have dynamic registration
-	if _, ok := oidc_provider_data["client_registration_url"]; ok {
+	if val, ok := oidc_provider_data["client_registration_url"]; ok && val != nil && len(val.(string)) > 0 {
 		body := newDynamicOIDCPostBody(name, oidc_provider_data)
 		return &idp.IdpPostBody{
 			OpenIDProviderDynamicPostBody: body,
 		}, diags
-
 	} else {
 		body := newManualOIDCPostBody(name, oidc_provider_data)
 		return &idp.IdpPostBody{
@@ -430,7 +429,7 @@ func newOIDCPatchBody(d *schema.ResourceData) (*idp.IdpPatchBody, diag.Diagnosti
 	oidc_provider := idp.NewOpenIDProviderPatchOidcProvider()
 	client := idp.NewOpenIDProviderPatchOidcProviderClient()
 	// in case we have dynamic registration
-	if client_registration_url, ok := oidc_provider_data["client_registration_url"]; ok {
+	if client_registration_url, ok := oidc_provider_data["client_registration_url"]; ok && client_registration_url != nil && len(client_registration_url.(string)) > 0 {
 		register_url := idp.NewOpenIDProviderPatchOidcProviderClientUrls()
 		register_url.SetRegister(client_registration_url.(string))
 		client.SetUrls(*register_url)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mulesoft-anypoint/anypoint-client-go/dlb v0.5.0
 	github.com/mulesoft-anypoint/anypoint-client-go/env v0.2.0
 	github.com/mulesoft-anypoint/anypoint-client-go/flexgateway v0.1.1
-	github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.0
+	github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.1
 	github.com/mulesoft-anypoint/anypoint-client-go/org v0.4.0
 	github.com/mulesoft-anypoint/anypoint-client-go/private_space v1.1.1
 	github.com/mulesoft-anypoint/anypoint-client-go/private_space_tlscontext v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/mulesoft-anypoint/anypoint-client-go/flexgateway v0.1.1 h1:iJ1iw6J3c8
 github.com/mulesoft-anypoint/anypoint-client-go/flexgateway v0.1.1/go.mod h1:tNX6qnXU2gnvGeQQInD9uKRK2Kcq1nKQdjgyzTZfWLQ=
 github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.0 h1:DOF515Dh3XgOXnxk/6V2efqoo3wMoxhH0y5MCXfLIec=
 github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.0/go.mod h1:GGCVuorW8c7mTWOFmLDC8nTn2nXgmGuJbDP/LNNPjug=
+github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.1 h1:Y7eCqsfYN06bVeMGLTusqO/S2YPO8LT3Mf1aS9o8BqM=
+github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.1/go.mod h1:GGCVuorW8c7mTWOFmLDC8nTn2nXgmGuJbDP/LNNPjug=
 github.com/mulesoft-anypoint/anypoint-client-go/org v0.4.0 h1:TOaHNJbX/aFMhFB8Y12TnHO+XSVr/mWv9ASU0QsdGf8=
 github.com/mulesoft-anypoint/anypoint-client-go/org v0.4.0/go.mod h1:6QFWuAYmlAtDYglheyxntcMEDxZSUV0jGbVKuXOElW8=
 github.com/mulesoft-anypoint/anypoint-client-go/private_space v1.1.1 h1:7Sq/668TQ2Cr6Fxkup1vWBNl3rJDarJz2/nDD/iLhX0=

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,6 @@ github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.0 h1:DOF515Dh3XgOXnxk/6
 github.com/mulesoft-anypoint/anypoint-client-go/idp v1.0.0/go.mod h1:GGCVuorW8c7mTWOFmLDC8nTn2nXgmGuJbDP/LNNPjug=
 github.com/mulesoft-anypoint/anypoint-client-go/org v0.4.0 h1:TOaHNJbX/aFMhFB8Y12TnHO+XSVr/mWv9ASU0QsdGf8=
 github.com/mulesoft-anypoint/anypoint-client-go/org v0.4.0/go.mod h1:6QFWuAYmlAtDYglheyxntcMEDxZSUV0jGbVKuXOElW8=
-github.com/mulesoft-anypoint/anypoint-client-go/private_space v1.1.0 h1:sSMATLQjNRnvulEoRXcA/l6TfDGbLB3RJd0+kcdscfU=
-github.com/mulesoft-anypoint/anypoint-client-go/private_space v1.1.0/go.mod h1:/HvCjbc2zxtr1Fgbanf5Uc/4a9JVdYg6OzQwVymDC9Q=
 github.com/mulesoft-anypoint/anypoint-client-go/private_space v1.1.1 h1:7Sq/668TQ2Cr6Fxkup1vWBNl3rJDarJz2/nDD/iLhX0=
 github.com/mulesoft-anypoint/anypoint-client-go/private_space v1.1.1/go.mod h1:/HvCjbc2zxtr1Fgbanf5Uc/4a9JVdYg6OzQwVymDC9Q=
 github.com/mulesoft-anypoint/anypoint-client-go/private_space_tlscontext v1.0.0 h1:S+yNQCmO1hfAsQQMrL+7r5/v5ugOsNmWiE1pjBGEOZY=


### PR DESCRIPTION
## Summary

Patch release focused on stabilizing **`anypoint_idp_oidc`** creation flows for both **Manual Registration** and **Dynamic Client Registration (DCR)**.

## Changelog (user-facing)

### 🐛 Bug Fixes

* **DCR creation fails with `oneOf(Idp)` schema error** — fixed the OIDC payload/shape handling so DCR providers can be created and read back successfully. Fixes 【#73】. ([GitHub][1])
* **Manual registration rejected with “Invalid OIDC provider client registration URL provided”** — corrected validation to **not** require/validate a client registration URL when manual credentials are supplied, unblocking creation. Fixes 【#53】. ([GitHub][2])

### 🔧 Maintenance

* Tightened IDP schema discrimination and request/response mapping for OIDC, improving diagnostics on create/read.

## Linked issues

* Closes #73 
* Closes #53 