### PR TITLE
Fix: Teams Data source

### DIFF
--- a/anypoint/data_source_teams.go
+++ b/anypoint/data_source_teams.go
@@ -36,7 +36,7 @@ func dataSourceTeams() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-							Description: "team_id that must appear in the team's ancestor_team_ids.",
+							Description: "List of team_ids that must appear in the team's ancestor_team_ids",
 						},
 						"parent_team_id": {
 							Type:     schema.TypeList,
@@ -44,7 +44,7 @@ func dataSourceTeams() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-							Description: "team_id of the immediate parent of the team to return.",
+							Description: "List of team_ids of the immediate parent of the team to return.",
 						},
 						"team_id": {
 							Type:        schema.TypeString,

--- a/docs/data-sources/teams.md
+++ b/docs/data-sources/teams.md
@@ -53,11 +53,11 @@ resource "anypoint_team" "team" {
 
 Optional:
 
-- `ancestor_team_id` (List of String) team_id that must appear in the team's ancestor_team_ids.
+- `ancestor_team_id` (List of String) List of team_ids that must appear in the team's ancestor_team_ids
 - `ascending` (Boolean) Whether to sort ascending or descending.
 - `limit` (Number) Maximum records to retrieve per request.
 - `offset` (Number) The number of records to omit from the response.
-- `parent_team_id` (List of String) team_id of the immediate parent of the team to return.
+- `parent_team_id` (List of String) List of team_ids of the immediate parent of the team to return.
 - `search` (String) A search string to use for case-insensitive partial matches on team name
 - `sort` (String) The field to sort on.
 - `team_id` (String) id of the team to return.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,14 +3,14 @@
 page_title: "anypoint_user Resource - terraform-provider-anypoint"
 subcategory: ""
 description: |-
-  Creates a `user` for your org. 
+  Creates a `user` for your org.
   
   N.B: you can use a username only once even after it's deleted.
 ---
 
 # anypoint_user (Resource)
 
-Creates a `user` for your org. 
+Creates a `user` for your org.
 
 **N.B:** you can use a username only once even after it's deleted.
 


### PR DESCRIPTION
Fix: 
* updates the description of fields `ancestor_team_id` and `parent_team_id`
* regenerates the documentation


Closes: #84 
