### PR TITLE
correct Elem schema in TypeList definitions

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -73,7 +73,9 @@ func dataSourceAME() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							Description: "Includes only results with the given Ids.",
-							Elem:        schema.TypeString,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -72,7 +72,9 @@ func dataSourceAMQ() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							Description: "Includes only results with the given Ids.",
-							Elem:        schema.TypeString,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},

--- a/anypoint/data_source_fabrics.go
+++ b/anypoint/data_source_fabrics.go
@@ -127,7 +127,9 @@ var FabricsIngressDomainsDefinition = &schema.Resource{
 			Type:        schema.TypeList,
 			Computed:    true,
 			Description: "The list of domains.",
-			Elem:        schema.TypeString,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
 		},
 	},
 }


### PR DESCRIPTION
Fixes #91
 
The `destination_ids` (AMQ, AME) and `domains` (fabrics) fields used
`Elem: schema.TypeString`, which passes a raw int value where the SDK
expects `*schema.Schema`. This caused a nil/interface panic inside
`serializeCollectionMemberForHash` during plan/refresh.
 
Changed all three occurrences to the proper nested schema form:
 
    Elem: &schema.Schema{
        Type: schema.TypeString,
    },
 
Files: data_source_amq.go, data_source_ame.go, data_source_fabrics.go

Closes #91 