### PR TITLE
fix(data-source): add empty-string guards and fix GetTotal method call

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -184,7 +184,7 @@ func parseAMESearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 			req = req.Limit(v.(int32))
 			continue
 		}
-		if k == "starts_with" {
+		if k == "starts_with" && v.(string) != "" {
 			req = req.StartsWith(v.(string))
 			continue
 		}

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -212,7 +212,7 @@ func parseAMQSearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 			req = req.Limit(v.(int32))
 			continue
 		}
-		if k == "starts_with" {
+		if k == "starts_with" && v.(string) != "" {
 			req = req.StartsWith(v.(string))
 			continue
 		}

--- a/anypoint/data_source_apim.go
+++ b/anypoint/data_source_apim.go
@@ -506,7 +506,7 @@ func parseApimSearchOpts(req apim.DefaultApiGetEnvApimInstancesRequest, params *
 			req = req.Limit(int32(v.(int)))
 			continue
 		}
-		if k == "sort" {
+		if k == "sort" && v.(string) != "" {
 			req = req.Sort(v.(string))
 			continue
 		}

--- a/anypoint/data_source_connected_apps.go
+++ b/anypoint/data_source_connected_apps.go
@@ -245,7 +245,7 @@ func parseConnectedAppSearchOpts(req connected_app.DefaultApiGetAllConnectedApps
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "search" {
+		if k == "search" && v.(string) != "" {
 			req = req.Search(v.(string))
 			continue
 		}

--- a/anypoint/data_source_team_groupmappings.go
+++ b/anypoint/data_source_team_groupmappings.go
@@ -127,7 +127,7 @@ func dataSourceTeamGroupMappingsRead(ctx context.Context, d *schema.ResourceData
 		return diags
 	}
 
-	if err := d.Set("total", res.GetTotal); err != nil {
+	if err := d.Set("total", res.GetTotal()); err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to set total number of team " + teamid + " gropumappings",


### PR DESCRIPTION
## Summary

Fixes two classes of data source bugs discovered while reviewing community PR #100. Optional string search parameters were forwarded to the API even when unset (empty string), causing RAML validation failures. One data source also passed a method reference `res.GetTotal` instead of calling it, leading to a type conversion panic.

## Changes

### Empty-string parameter guards (RAML validation failures)

| File | Parameter | Before | After |
|------|-----------|--------|-------|
| [data_source_amq.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_amq.go:0:0-0:0) | `starts_with` | always sent | guarded with `!= ""` |
| [data_source_ame.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_ame.go:0:0-0:0) | `starts_with` | always sent | guarded with `!= ""` |
| [data_source_apim.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_apim.go:0:0-0:0) | `sort` | always sent | guarded with `!= ""` |
| [data_source_connected_apps.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_connected_apps.go:0:0-0:0) | `search` | always sent | guarded with `!= ""` |

Same pattern already fixed in [data_source_team_members.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_team_members.go:0:0-0:0) (PR #100), [data_source_team_roles.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_team_roles.go:0:0-0:0), and [data_source_teams.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_teams.go:0:0-0:0).

### Method reference panic

| File | Field | Before | After |
|------|-------|--------|-------|
| [data_source_team_groupmappings.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_team_groupmappings.go:0:0-0:0) | `total` | `res.GetTotal` (func) | `res.GetTotal()` (int32) |

Same bug fixed in PR #100 for [data_source_team_members.go](cci:7://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_team_members.go:0:0-0:0).

## Verification

- `make build` passes
- No schema or API behavior changes — purely defensive

## Related

- PR #100 — same bug patterns reported and fixed by community
- Issue #84 — teams filtering params
- Issue #91 — `Elem` schema crash