### PR TITLE
fix(data-source): cast int to int32 for AMQ/AME offset and limit params

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -177,11 +177,11 @@ func parseAMESearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(v.(int32))
+			req = req.Offset(int32(v.(int)))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(v.(int32))
+			req = req.Limit(int32(v.(int)))
 			continue
 		}
 		if k == "starts_with" {

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -205,11 +205,11 @@ func parseAMQSearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(v.(int32))
+			req = req.Offset(int32(v.(int)))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(v.(int32))
+			req = req.Limit(int32(v.(int)))
 			continue
 		}
 		if k == "starts_with" {


### PR DESCRIPTION
Fixes https://github.com/mulesoft-anypoint/terraform-provider-anypoint/issues/102.

Problem
anypoint_amq and anypoint_ame data sources crash with:

panic: interface conversion: interface {} is int, not int32
when params block contains offset or limit values.

Root Cause
Terraform Plugin SDK v2 stores schema.TypeInt values as Go int internally. The parseAMQSearchOpts and parseAMESearchOpts functions were asserting the raw value directly to int32:

req = req.Offset(v.(int32)) // panic: interface {} is int, not int32
All other data sources already use the safe pattern int32(v.(int)).

Fix

data_source_amq.go: changed offset and limit assertions to int32(v.(int)).
data_source_ame.go: changed offset and limit assertions to int32(v.(int)).
Verification

make build passes with no new warnings.
Stack trace from https://github.com/mulesoft-anypoint/terraform-provider-anypoint/issues/102 points to line 208/212 (parseAMQSearchOpts), which is now covered by the corrected cast.
Scope
Purely defensive type-conversion fix — no API or schema changes. Only affects the two Anypoint MQ data sources.