### PR TITLE
Release v1.8.4 — Data source crash & validation fixes

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -184,7 +184,7 @@ func parseAMESearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 			req = req.Limit(v.(int32))
 			continue
 		}
-		if k == "starts_with" {
+		if k == "starts_with" && v.(string) != "" {
 			req = req.StartsWith(v.(string))
 			continue
 		}

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -212,7 +212,7 @@ func parseAMQSearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 			req = req.Limit(v.(int32))
 			continue
 		}
-		if k == "starts_with" {
+		if k == "starts_with" && v.(string) != "" {
 			req = req.StartsWith(v.(string))
 			continue
 		}

--- a/anypoint/data_source_apim.go
+++ b/anypoint/data_source_apim.go
@@ -506,7 +506,7 @@ func parseApimSearchOpts(req apim.DefaultApiGetEnvApimInstancesRequest, params *
 			req = req.Limit(int32(v.(int)))
 			continue
 		}
-		if k == "sort" {
+		if k == "sort" && v.(string) != "" {
 			req = req.Sort(v.(string))
 			continue
 		}

--- a/anypoint/data_source_connected_apps.go
+++ b/anypoint/data_source_connected_apps.go
@@ -245,7 +245,7 @@ func parseConnectedAppSearchOpts(req connected_app.DefaultApiGetAllConnectedApps
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "search" {
+		if k == "search" && v.(string) != "" {
 			req = req.Search(v.(string))
 			continue
 		}

--- a/anypoint/data_source_team_groupmappings.go
+++ b/anypoint/data_source_team_groupmappings.go
@@ -127,7 +127,7 @@ func dataSourceTeamGroupMappingsRead(ctx context.Context, d *schema.ResourceData
 		return diags
 	}
 
-	if err := d.Set("total", res.GetTotal); err != nil {
+	if err := d.Set("total", res.GetTotal()); err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to set total number of team " + teamid + " gropumappings",


### PR DESCRIPTION
Merges the latest bug fixes from `dev` into `master` to prepare the **v1.8.4** patch release.

### Changes included

| PR | Change | Scope |
|---|---|---|
| #101 | fix(data-source): add empty-string guards and fix `GetTotal` method call | `anypoint_amq`, `anypoint_ame`, `anypoint_apim`, `anypoint_connected_apps`, `anypoint_team_groupmappings` |
| #105 | fix(data-source): cast `int` to `int32` for AMQ/AME offset and limit params | `anypoint_amq`, `anypoint_ame` |
| *(already in master)* #100 | fix(data-source): resolve two bugs in `anypoint_team_members` | `anypoint_team_members` |

### Release checklist
- [x] All PRs merged to `dev`
- [x] `make build` passes
- [ ] Tag `v1.8.4` after merge
- [ ] Publish release notes

### Related issues
- #102 — AMQ/AME `offset`/`limit` panic
- Fixes from community PR #100 review cycle