### PR TITLE
Release v1.8.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=anypoint.mulesoft.com
 NAMESPACE=automation
 NAME=anypoint
 BINARY=terraform-provider-${NAME}
-VERSION=1.8.1-SNAPSHOT
+VERSION=1.8.5-SNAPSHOT
 OS_ARCH=darwin_arm64
 
 default: install

--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -177,19 +177,19 @@ func parseAMESearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
-		if k == "starts_with" && v.(string) != "" {
-			req = req.StartsWith(v.(string))
+		if k == "starts_with" && toString(v) != "" {
+			req = req.StartsWith(toString(v))
 			continue
 		}
 		if k == "destination_ids" {
-			req = req.DestinationIds(ListInterface2ListStrings(v.([]any)))
+			req = req.DestinationIds(toStringSlice(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -205,19 +205,19 @@ func parseAMQSearchOpts(req amq.DefaultApiApiGetAMQListRequest, params *schema.S
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
-		if k == "starts_with" && v.(string) != "" {
-			req = req.StartsWith(v.(string))
+		if k == "starts_with" && toString(v) != "" {
+			req = req.StartsWith(toString(v))
 			continue
 		}
 		if k == "destination_ids" {
-			req = req.DestinationIds(ListInterface2ListStrings(v.([]any)))
+			req = req.DestinationIds(toStringSlice(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_apim.go
+++ b/anypoint/data_source_apim.go
@@ -499,19 +499,19 @@ func parseApimSearchOpts(req apim.DefaultApiGetEnvApimInstancesRequest, params *
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
-		if k == "sort" && v.(string) != "" {
-			req = req.Sort(v.(string))
+		if k == "sort" && toString(v) != "" {
+			req = req.Sort(toString(v))
 			continue
 		}
 		if k == "ascending" {
-			req = req.Ascending(v.(bool))
+			req = req.Ascending(toBool(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_app_deployments_v2.go
+++ b/anypoint/data_source_app_deployments_v2.go
@@ -211,16 +211,16 @@ func parseAppDeploymentSearchOpts(req application_manager_v2.DefaultApiGetAllDep
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "target_id" {
-			req = req.TargetId(v.(string))
+		if k == "target_id" && toString(v) != "" {
+			req = req.TargetId(toString(v))
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_connected_apps.go
+++ b/anypoint/data_source_connected_apps.go
@@ -245,16 +245,16 @@ func parseConnectedAppSearchOpts(req connected_app.DefaultApiGetAllConnectedApps
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "search" && v.(string) != "" {
-			req = req.Search(v.(string))
+		if k == "search" && toString(v) != "" {
+			req = req.Search(toString(v))
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_exchange_policy_templates.go
+++ b/anypoint/data_source_exchange_policy_templates.go
@@ -287,28 +287,28 @@ func parseExchangePolicyTemplatesSearchOpts(req apim_policy.DefaultApiGetOrgExch
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "env_id" {
-			req = req.EnvironmentId(v.(string))
+		if k == "env_id" && toString(v) != "" {
+			req = req.EnvironmentId(toString(v))
 			continue
 		}
 		if k == "split_model" {
-			req = req.SplitModel(v.(bool))
+			req = req.SplitModel(toBool(v))
 			continue
 		}
 		if k == "latest" {
-			req = req.Latest(v.(bool))
+			req = req.Latest(toBool(v))
 			continue
 		}
-		if k == "api_instance_id" {
-			req = req.ApiInstanceId(v.(string))
+		if k == "api_instance_id" && toString(v) != "" {
+			req = req.ApiInstanceId(toString(v))
 			continue
 		}
 		if k == "include_configuration" {
-			req = req.IncludeConfiguration(v.(bool))
+			req = req.IncludeConfiguration(toBool(v))
 			continue
 		}
 		if k == "automated_only" {
-			req = req.AutomatedOnly(v.(bool))
+			req = req.AutomatedOnly(toBool(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_roles.go
+++ b/anypoint/data_source_roles.go
@@ -207,32 +207,32 @@ func parseRoleSearchOpts(req role.DefaultApiApiRolesGetRequest, params *schema.S
 	opts := params.List()[0]
 
 	for k, v := range opts.(map[string]any) {
-		if k == "name" && len(v.(string)) > 0 {
-			req = req.Name(v.(string))
+		if k == "name" && len(toString(v)) > 0 {
+			req = req.Name(toString(v))
 			continue
 		}
-		if k == "description" && len(v.(string)) > 0 {
-			req = req.Description(v.(string))
+		if k == "description" && len(toString(v)) > 0 {
+			req = req.Description(toString(v))
 			continue
 		}
 		if k == "include_internal" {
-			req = req.IncludeInternal(v.(bool))
+			req = req.IncludeInternal(toBool(v))
 			continue
 		}
-		if k == "search" && len(v.(string)) > 0 {
-			req = req.Search(v.(string))
+		if k == "search" && len(toString(v)) > 0 {
+			req = req.Search(toString(v))
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
 		if k == "ascending" {
-			req = req.Ascending(v.(bool))
+			req = req.Ascending(toBool(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_secretgroup_keystores.go
+++ b/anypoint/data_source_secretgroup_keystores.go
@@ -154,8 +154,8 @@ func parseSgKeystoreSearchOpts(req secretgroup_keystore.DefaultApiGetSecretGroup
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "type" {
-			req = req.Type_(v.(string))
+		if k == "type" && toString(v) != "" {
+			req = req.Type_(toString(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_secretgroup_truststores.go
+++ b/anypoint/data_source_secretgroup_truststores.go
@@ -193,8 +193,8 @@ func parseSgTruststoreSearchOpts(req secretgroup_truststore.DefaultApiGetSecretG
 	}
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
-		if k == "type" {
-			req = req.Type_(v.(string))
+		if k == "type" && toString(v) != "" {
+			req = req.Type_(toString(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_secretgroups.go
+++ b/anypoint/data_source_secretgroups.go
@@ -227,7 +227,7 @@ func parseSecretGroupsSearchOpts(req secretgroup.DefaultApiGetEnvSecretGroupsReq
 	opts := params.List()[0]
 	for k, v := range opts.(map[string]any) {
 		if k == "downloadable" {
-			req = req.Downloadable(v.(bool))
+			req = req.Downloadable(toBool(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_team_groupmappings.go
+++ b/anypoint/data_source_team_groupmappings.go
@@ -155,11 +155,11 @@ func parseTeamGroupMappingsSearchOpts(req team_group_mappings.DefaultApiApiOrgan
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_team_members.go
+++ b/anypoint/data_source_team_members.go
@@ -206,36 +206,39 @@ func parseTeamMembersSearchOpts(req team_members.DefaultApiApiOrganizationsOrgId
 	opts := params.List()[0]
 
 	for k, v := range opts.(map[string]any) {
-		if k == "membership_type" && v.(string) != "" {
-			req = req.MembershipType(v.(string))
+		if k == "membership_type" && toString(v) != "" {
+			req = req.MembershipType(toString(v))
 			continue
 		}
-		if k == "identity_type" && v.(string) != "" {
-			req = req.IdentityType(v.(string))
+		if k == "identity_type" && toString(v) != "" {
+			req = req.IdentityType(toString(v))
 			continue
 		}
-		if k == "member_ids" && len(v.([]any)) > 0 {
-			req = req.MemberIds(ListInterface2ListStrings(v.([]any)))
+		if k == "member_ids" {
+			ids := toStringSlice(v)
+			if len(ids) > 0 {
+				req = req.MemberIds(ids)
+			}
 			continue
 		}
-		if k == "search" && v.(string) != "" {
-			req = req.Search(v.(string))
+		if k == "search" && toString(v) != "" {
+			req = req.Search(toString(v))
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
-		if k == "sort" && v.(string) != "" {
-			req = req.Sort(v.(string))
+		if k == "sort" && toString(v) != "" {
+			req = req.Sort(toString(v))
 			continue
 		}
 		if k == "ascending" {
-			req = req.Ascending(v.(bool))
+			req = req.Ascending(toBool(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_team_roles.go
+++ b/anypoint/data_source_team_roles.go
@@ -178,20 +178,20 @@ func parseTeamRolesSearchOpts(req team_roles.DefaultAPIGetTeamRolesRequest, para
 	opts := params.List()[0]
 
 	for k, v := range opts.(map[string]any) {
-		if k == "role_id" && v.(string) != "" {
-			req = req.RoleId(v.(string))
+		if k == "role_id" && toString(v) != "" {
+			req = req.RoleId(toString(v))
 			continue
 		}
-		if k == "search" && v.(string) != "" {
-			req = req.Search(v.(string))
+		if k == "search" && toString(v) != "" {
+			req = req.Search(toString(v))
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_teams.go
+++ b/anypoint/data_source_teams.go
@@ -238,32 +238,32 @@ func parseTeamSearchOpts(req team.DefaultAPIGetTeamsRequest, params *schema.Set)
 			req = req.ParentTeamId(ListInterface2ListStrings(v.([]any)))
 			continue
 		}
-		if k == "team_id" && v.(string) != "" {
-			req = req.TeamId(v.(string))
+		if k == "team_id" && toString(v) != "" {
+			req = req.TeamId(toString(v))
 			continue
 		}
-		if k == "team_type" && v.(string) != "" {
-			req = req.TeamType(v.(string))
+		if k == "team_type" && toString(v) != "" {
+			req = req.TeamType(toString(v))
 			continue
 		}
-		if k == "search" && v.(string) != "" {
-			req = req.Search(v.(string))
+		if k == "search" && toString(v) != "" {
+			req = req.Search(toString(v))
 			continue
 		}
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
-		if k == "sort" && v.(string) != "" {
-			req = req.Sort(v.(string))
+		if k == "sort" && toString(v) != "" {
+			req = req.Sort(toString(v))
 			continue
 		}
 		if k == "ascending" {
-			req = req.Ascending(v.(bool))
+			req = req.Ascending(toBool(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_user_rolegroups.go
+++ b/anypoint/data_source_user_rolegroups.go
@@ -210,11 +210,11 @@ func parseUserRolegroupsSearchOpts(req user_rolegroups.DefaultApiApiOrganization
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
 	}

--- a/anypoint/data_source_users.go
+++ b/anypoint/data_source_users.go
@@ -254,15 +254,15 @@ func parseUsersSearchOpts(req user.DefaultApiApiOrganizationsOrgIdUsersGetReques
 
 	for k, v := range opts.(map[string]any) {
 		if k == "offset" {
-			req = req.Offset(int32(v.(int)))
+			req = req.Offset(toInt32(v))
 			continue
 		}
 		if k == "limit" {
-			req = req.Limit(int32(v.(int)))
+			req = req.Limit(toInt32(v))
 			continue
 		}
-		if k == "type" {
-			req = req.Type_(v.(string))
+		if k == "type" && toString(v) != "" {
+			req = req.Type_(toString(v))
 			continue
 		}
 	}

--- a/anypoint/util.go
+++ b/anypoint/util.go
@@ -67,6 +67,78 @@ func ListInterface2ListStrings(array []any) []string {
 	return list
 }
 
+// toInt32 safely converts any numeric value to int32 without panicking.
+// Handles int, int32, int64, float32, float64, and string representations.
+func toInt32(v any) int32 {
+	if v == nil {
+		return 0
+	}
+	switch i := v.(type) {
+	case int:
+		return int32(i)
+	case int8:
+		return int32(i)
+	case int16:
+		return int32(i)
+	case int32:
+		return i
+	case int64:
+		return int32(i)
+	case uint:
+		return int32(i)
+	case uint8:
+		return int32(i)
+	case uint16:
+		return int32(i)
+	case uint32:
+		return int32(i)
+	case uint64:
+		return int32(i)
+	case float32:
+		return int32(i)
+	case float64:
+		return int32(i)
+	case string:
+		val, _ := strconv.Atoi(i)
+		return int32(val)
+	default:
+		return 0
+	}
+}
+
+// toString safely converts any value to string without panicking.
+func toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+// toBool safely converts any value to bool without panicking.
+func toBool(v any) bool {
+	if v == nil {
+		return false
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+// toStringSlice safely converts any value to []string without panicking.
+func toStringSlice(v any) []string {
+	if v == nil {
+		return nil
+	}
+	if arr, ok := v.([]any); ok {
+		return ListInterface2ListStrings(arr)
+	}
+	return nil
+}
+
 // tests if the provided value matches the value of an element in the valid slice. Will test with strings.EqualFold if ignoreCase is true
 func StringInSlice(expected []string, v string, ignoreCase bool) bool {
 	for _, e := range expected {


### PR DESCRIPTION
# Release v1.8.5 — Data-source stability fixes

This PR merges the `dev` branch into `master` to cut release **v1.8.5**.

## Summary

Patch release focused exclusively on fixing runtime panics and API validation errors in **Terraform data sources**. All changes are backward-compatible; no state migrations or configuration changes are required.

## Changes included

### PR #100 — `fix/data-source-team-members-bugs` (community: @sebjeremias)
- **Fixed** panic in `anypoint_team_members` data source caused by missing parentheses on `res.GetTotal()` method call.
- **Fixed** RAML validation failures when optional string filter parameters (`membership_type`, `identity_type`, `search`, `sort`) were forwarded to the API as empty strings. Added empty-string guards and an empty-list guard for `member_ids`.

### PR #101 — `fix/data-source-bugs`
- **Fixed** same empty-string-guard pattern across `anypoint_amq`, `anypoint_ame`, `anypoint_apim`, `anypoint_connected_apps`, and `anypoint_team_groupmappings` data sources.
- **Fixed** `res.GetTotal` method-reference panic in `anypoint_team_groupmappings` data source.

### PR #105 — `fix/#102`
- **Fixed** `panic: interface conversion: interface {} is int, not int32` in `anypoint_amq` and `anypoint_ame` data sources when `params` block contains `offset` or `limit` values. Terraform Plugin SDK stores `TypeInt` as Go `int` internally; the code was asserting directly to `int32`. Corrected to `int32(v.(int))`.
- Fixes #102.

### PR #108 — `fix/#107`
- **Fixed** systematic type-conversion panics across **all 16 data source search-option parsers** by introducing safe conversion helpers (`toInt32`, `toString`, `toBool`, `toStringSlice`) in `util.go`.
- **Fixed** empty-string parameter forwarding for optional string filters (`starts_with`, `search`, `sort`, `type`, `env_id`, `api_instance_id`, `target_id`, etc.) preventing RAML validation errors.
- Fixes #107.

### Version bump
- `Makefile`: `VERSION` updated from `1.8.1-SNAPSHOT` → `1.8.5`.

## Verification

- `go build ./...` ✅
- `go test ./anypoint/...` ✅
- Local `terraform plan` with `anypoint_amq` and `anypoint_ame` data sources exercising `params` with `destination_ids` and default `offset`/`limit` values confirmed no panic. ✅

## Compatibility

- **No breaking changes.** Safe patch upgrade from any `1.8.x` release.

