### PR TITLE
fix(#110): add local filtering for destination_ids in AMQ and AME data sources

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -145,10 +145,13 @@ func dataSourceAMERead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		return diags
 	}
 	defer httpr.Body.Close()
+	// filter by destination_ids since API ignores it
+	res = filterAMQDestinationsByIds(res, searchopts)
+
 	//process data
-	amqinstance := flattenAMEsData(&res)
+	ameinstance := flattenAMEsData(&res)
 	//save in data source schema
-	if err := d.Set("exchanges", amqinstance); err != nil {
+	if err := d.Set("exchanges", ameinstance); err != nil {
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to set AMEs",

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -173,6 +173,9 @@ func dataSourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		return diags
 	}
 	defer httpr.Body.Close()
+	// filter by destination_ids since API ignores it
+	res = filterAMQDestinationsByIds(res, searchopts)
+
 	//process data
 	amqinstance := flattenAMQsData(&res)
 	//save in data source schema
@@ -188,6 +191,40 @@ func dataSourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 
 	return diags
+}
+
+// NOTE: Temporary workaround because Anypoint MQ API ignores 'destinationIds' query param.
+// It manually filters the results locally. Remove this once Mulesoft fixes the underlying API to honor 'destinationIds'.
+func filterAMQDestinationsByIds(destinations []amq.Queue, searchopts *schema.Set) []amq.Queue {
+	if searchopts == nil || searchopts.Len() == 0 {
+		return destinations
+	}
+	opts := searchopts.List()[0].(map[string]any)
+	destIdsRaw, ok := opts["destination_ids"]
+	if !ok {
+		return destinations
+	}
+	destIds := toStringSlice(destIdsRaw)
+	if len(destIds) == 0 {
+		return destinations
+	}
+
+	idMap := make(map[string]bool)
+	for _, id := range destIds {
+		idMap[id] = true
+	}
+
+	filtered := make([]amq.Queue, 0)
+	for _, q := range destinations {
+		id := q.GetQueueId()
+		if id == "" {
+			id = q.GetExchangeId()
+		}
+		if idMap[id] {
+			filtered = append(filtered, q)
+		}
+	}
+	return filtered
 }
 
 // Parses search parameters


### PR DESCRIPTION
## What's Changed

Fixes #110.

Anypoint MQ API completely ignores the `destinationIds` query parameter when fetching lists. The API always returns the full list of queues/exchanges for the environment, which caused the Terraform provider to return 90+ elements even when users only requested 1 ID via `destination_ids` in the `params` block.

This PR adds a temporary local filtering workaround directly in the provider.

### 🐛 Bug Fixes
- **`anypoint_amq` and `anypoint_ame` data sources** — Added [filterAMQDestinationsByIds](cci:1://file:///Users/souf/Workspaces/cat/Anypoint-Devops-Collective/terraform-provider-anypoint/anypoint/data_source_amq.go:195:0-227:1) to manually filter results locally after the `req.Execute()` API call, before they are mapped and saved into the schema. 
- Results are now correctly limited to exactly the IDs passed to `destination_ids` if that parameter is set.

> **Note:** The local filter function has been annotated with a comment to ensure we remove it once Mulesoft fixes the underlying API endpoint to properly respect the `destinationIds` query parameter.