### PR TITLE
Relese v1.8.6

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -145,10 +145,13 @@ func dataSourceAMERead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		return diags
 	}
 	defer httpr.Body.Close()
+	// filter by destination_ids since API ignores it
+	res = filterAMQDestinationsByIds(res, searchopts)
+
 	//process data
-	amqinstance := flattenAMEsData(&res)
+	ameinstance := flattenAMEsData(&res)
 	//save in data source schema
-	if err := d.Set("exchanges", amqinstance); err != nil {
+	if err := d.Set("exchanges", ameinstance); err != nil {
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to set AMEs",

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -173,6 +173,9 @@ func dataSourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		return diags
 	}
 	defer httpr.Body.Close()
+	// filter by destination_ids since API ignores it
+	res = filterAMQDestinationsByIds(res, searchopts)
+
 	//process data
 	amqinstance := flattenAMQsData(&res)
 	//save in data source schema
@@ -188,6 +191,40 @@ func dataSourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 
 	return diags
+}
+
+// NOTE: Temporary workaround because Anypoint MQ API ignores 'destinationIds' query param.
+// It manually filters the results locally. Remove this once Mulesoft fixes the underlying API to honor 'destinationIds'.
+func filterAMQDestinationsByIds(destinations []amq.Queue, searchopts *schema.Set) []amq.Queue {
+	if searchopts == nil || searchopts.Len() == 0 {
+		return destinations
+	}
+	opts := searchopts.List()[0].(map[string]any)
+	destIdsRaw, ok := opts["destination_ids"]
+	if !ok {
+		return destinations
+	}
+	destIds := toStringSlice(destIdsRaw)
+	if len(destIds) == 0 {
+		return destinations
+	}
+
+	idMap := make(map[string]bool)
+	for _, id := range destIds {
+		idMap[id] = true
+	}
+
+	filtered := make([]amq.Queue, 0)
+	for _, q := range destinations {
+		id := q.GetQueueId()
+		if id == "" {
+			id = q.GetExchangeId()
+		}
+		if idMap[id] {
+			filtered = append(filtered, q)
+		}
+	}
+	return filtered
 }
 
 // Parses search parameters


### PR DESCRIPTION
# Release v1.8.6 — AMQ/AME destination_ids filtering fix

This PR merges the `dev` branch into `master` to cut release **v1.8.6**.

## Summary

Patch release fixing `destination_ids` filtering in the `anypoint_amq` and `anypoint_ame` data sources. The Anypoint MQ API silently ignores the `destinationIds` query parameter, causing the data source to return unfiltered results even when `destination_ids` is specified in the `params` block. This release adds client-side filtering as a workaround. All changes are backward-compatible; no state migrations or configuration changes are required.

## Changes included

### PR #111 — `fix/#110`
- **Fixed** `destination_ids` filter being ignored by the Anypoint MQ API in `anypoint_amq` and `anypoint_ame` data sources. Added `filterAMQDestinationsByIds()` helper that performs local filtering on the API response when `destination_ids` is specified in the `params` block.
- **Fixed** misleading variable name in `data_source_ame.go` — `amqinstance` renamed to `ameinstance` for clarity.
- Fixes #110.

### Version bump
- `Makefile`: `VERSION` updated from `1.8.5-SNAPSHOT` → `1.8.6`.

## Verification

- `go build ./...` ✅
- `go test ./anypoint/...` ✅
- Local `terraform plan` with `anypoint_amq` and `anypoint_ame` data sources exercising `params` with `destination_ids` confirmed results are now correctly filtered. ✅

## Compatibility

- **No breaking changes.** Safe patch upgrade from any `1.8.x` release.
