### PR TITLE
fix(read): guard Read funcs against 404 (#17)

### DIFF
--- a/anypoint/resource_ame.go
+++ b/anypoint/resource_ame.go
@@ -136,6 +136,10 @@ func resourceAMERead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	//request resource
 	res, httpr, err := pco.ameclient.DefaultApi.GetAME(authctx, orgid, envid, regionid, exchangeid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_ame_binding.go
+++ b/anypoint/resource_ame_binding.go
@@ -350,6 +350,10 @@ func resourceAMEBindingRead(ctx context.Context, d *schema.ResourceData, m any) 
 	//request resource
 	res, httpr, err := pco.amebindingclient.DefaultApi.GetAMEBinding(authctx, orgid, envid, regionid, exchangeid, queueid).Inclusion("ALL").Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_amq.go
+++ b/anypoint/resource_amq.go
@@ -170,6 +170,10 @@ func resourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	//request resource
 	res, httpr, err := pco.amqclient.DefaultApi.GetAMQ(authctx, orgid, envid, regionid, queueid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_flexgateway.go
+++ b/anypoint/resource_apim_flexgateway.go
@@ -585,6 +585,10 @@ func resourceApimFlexGatewayRead(ctx context.Context, d *schema.ResourceData, m 
 
 	res, httpr, err := pco.apimclient.DefaultApi.GetApimInstanceDetails(authctx, orgid, envid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_mule4.go
+++ b/anypoint/resource_apim_mule4.go
@@ -250,6 +250,10 @@ func resourceApimMule4Read(ctx context.Context, d *schema.ResourceData, m any) d
 	//perform request
 	res, httpr, err := pco.apimclient.DefaultApi.GetApimInstanceDetails(authctx, orgid, envid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_policy_basic_auth.go
+++ b/anypoint/resource_apim_policy_basic_auth.go
@@ -213,6 +213,10 @@ func resourceApimInstancePolicyBasicAuthRead(ctx context.Context, d *schema.Reso
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_policy_client_id_enforcement.go
+++ b/anypoint/resource_apim_policy_client_id_enforcement.go
@@ -233,6 +233,10 @@ func resourceApimInstancePolicyClientIdEnfRead(ctx context.Context, d *schema.Re
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_policy_custom.go
+++ b/anypoint/resource_apim_policy_custom.go
@@ -204,6 +204,10 @@ func resourceApimInstancePolicyCustomRead(ctx context.Context, d *schema.Resourc
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_policy_jwt_validation.go
+++ b/anypoint/resource_apim_policy_jwt_validation.go
@@ -448,6 +448,10 @@ func resourceApimInstancePolicyJwtValidationRead(ctx context.Context, d *schema.
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_policy_message_logging.go
+++ b/anypoint/resource_apim_policy_message_logging.go
@@ -267,6 +267,10 @@ func resourceApimInstancePolicyMessageLoggingRead(ctx context.Context, d *schema
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_apim_policy_rate_limit.go
+++ b/anypoint/resource_apim_policy_rate_limit.go
@@ -253,6 +253,10 @@ func resourceApimInstancePolicyRateLimitingRead(ctx context.Context, d *schema.R
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_bg.go
+++ b/anypoint/resource_bg.go
@@ -819,6 +819,10 @@ func resourceBGRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 	//perform request
 	res, httpr, err := pco.orgclient.DefaultApi.OrganizationsOrgIdGet(authctx, orgid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_cloudhub2_shared_space_deployment.go
+++ b/anypoint/resource_cloudhub2_shared_space_deployment.go
@@ -574,6 +574,10 @@ func resourceCloudhub2SharedSpaceDeploymentRead(ctx context.Context, d *schema.R
 	//perform request
 	res, httpr, err := pco.appmanagerclient.DefaultApi.GetDeploymentById(authctx, orgid, envid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_connected_app.go
+++ b/anypoint/resource_connected_app.go
@@ -250,6 +250,10 @@ func resourceConnectedAppRead(ctx context.Context, d *schema.ResourceData, m any
 		res, httpr, err = pco.connectedappclient.DefaultApi.GetConnectedAppByIdOnly(authctx, connappid).Execute()
 	}
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_dlb.go
+++ b/anypoint/resource_dlb.go
@@ -408,6 +408,10 @@ func resourceDLBRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	//request roles
 	res, httpr, err := pco.dlbclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdLoadbalancersDlbIdGet(authctx, orgid, vpcid, dlbid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_env.go
+++ b/anypoint/resource_env.go
@@ -113,6 +113,10 @@ func resourceENVRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	//perform request
 	res, httpr, err := pco.envclient.DefaultApi.OrganizationsOrgIdEnvironmentsEnvironmentIdGet(authctx, orgid, envid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_fabrics.go
+++ b/anypoint/resource_fabrics.go
@@ -221,6 +221,10 @@ func resourceFabricsRead(ctx context.Context, d *schema.ResourceData, m any) dia
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetFabrics(authctx, orgid, fabricsid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_fabrics_associations.go
+++ b/anypoint/resource_fabrics_associations.go
@@ -128,6 +128,10 @@ func resourceFabricsAssociationsRead(ctx context.Context, d *schema.ResourceData
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetFabricsAssociations(authctx, orgid, fabricsid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_idp_oidc.go
+++ b/anypoint/resource_idp_oidc.go
@@ -194,6 +194,10 @@ func resourceOIDCRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	//perform request
 	res, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdGet(authctx, orgid, idpid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_idp_saml.go
+++ b/anypoint/resource_idp_saml.go
@@ -200,6 +200,10 @@ func resourceSAMLRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	//perform request
 	res, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdGet(authctx, orgid, idpid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_private_space.go
+++ b/anypoint/resource_private_space.go
@@ -229,6 +229,10 @@ func resourcePrivateSpaceRead(ctx context.Context, d *schema.ResourceData, m any
 	//request
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpace(authctx, orgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_private_space_tlscontext_jks.go
+++ b/anypoint/resource_private_space_tlscontext_jks.go
@@ -258,6 +258,10 @@ func resourcePrivateSpaceTlsContextJKSRead(ctx context.Context, d *schema.Resour
 	//request
 	tlscontext, httpr, err := pco.privatespacetlscontextclient.DefaultApi.GetTlsContext(authctx, orgid, private_space_id, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_private_space_tlscontext_pem.go
+++ b/anypoint/resource_private_space_tlscontext_pem.go
@@ -258,6 +258,10 @@ func resourcePrivateSpaceTlsContextPemRead(ctx context.Context, d *schema.Resour
 	//request
 	res, httpr, err := pco.privatespacetlscontextclient.DefaultApi.GetTlsContext(authctx, orgid, private_space_id, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_private_space_transit_gateway.go
+++ b/anypoint/resource_private_space_transit_gateway.go
@@ -153,6 +153,10 @@ func resourcePrivateSpaceTransitGatewayRead(ctx context.Context, d *schema.Resou
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	list, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceTransitGateways(authctx, orgid, psid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_rolegroup.go
+++ b/anypoint/resource_rolegroup.go
@@ -140,6 +140,10 @@ func resourceRoleGroupRead(ctx context.Context, d *schema.ResourceData, m any) d
 	//perform request
 	res, httpr, err := pco.rolegroupclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdGet(authctx, orgid, rolegroupid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_rolegroup_roles.go
+++ b/anypoint/resource_rolegroup_roles.go
@@ -151,6 +151,10 @@ func resourceRoleGroupRolesRead(ctx context.Context, d *schema.ResourceData, m a
 	//perform request
 	res, httpr, err := pco.roleclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdRolesGet(authctx, org_id, rolegroup_id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_rtf_deployment.go
+++ b/anypoint/resource_rtf_deployment.go
@@ -625,6 +625,10 @@ func resourceRTFDeploymentRead(ctx context.Context, d *schema.ResourceData, m an
 	//perform request
 	res, httpr, err := pco.appmanagerclient.DefaultApi.GetDeploymentById(authctx, orgid, envid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup.go
+++ b/anypoint/resource_secretgroup.go
@@ -145,6 +145,10 @@ func resourceSecretGroupRead(ctx context.Context, d *schema.ResourceData, m any)
 	authctx := getSecretGroupAuthCtx(ctx, &pco)
 	res, httpr, err := pco.secretgroupclient.DefaultApi.GetSecretGroup(authctx, orgid, envid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_certificate.go
+++ b/anypoint/resource_secretgroup_certificate.go
@@ -172,6 +172,10 @@ func resourceSecretGroupCertificateRead(ctx context.Context, d *schema.ResourceD
 	//perform request
 	res, httpr, err := pco.sgcertificateclient.DefaultApi.GetSecretGroupCertificateDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_crldistrib_cfgs.go
+++ b/anypoint/resource_secretgroup_crldistrib_cfgs.go
@@ -155,6 +155,10 @@ func resourceSecretGroupCrlDistribCfgsRead(ctx context.Context, d *schema.Resour
 	//perform request
 	res, httpr, err := pco.sgcrldistribcfgsclient.DefaultApi.GetSecretGroupCrlDistribCfgsDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_keystore.go
+++ b/anypoint/resource_secretgroup_keystore.go
@@ -242,7 +242,11 @@ func resourceSecretGroupKeystoreRead(ctx context.Context, d *schema.ResourceData
 	}
 	authctx := getSgKeystoreAuthCtx(ctx, &pco)
 	res, httpr, err := pco.sgkeystoreclient.DefaultApi.GetSecretGroupKeystoreDetails(authctx, orgid, envid, sgid, id).Execute()
-	if err != nil && httpr.StatusCode >= 400 {
+	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_tlscontext_flexgateway.go
+++ b/anypoint/resource_secretgroup_tlscontext_flexgateway.go
@@ -245,6 +245,10 @@ func resourceSecretGroupTlsContextFGRead(ctx context.Context, d *schema.Resource
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_tlscontext_mule.go
+++ b/anypoint/resource_secretgroup_tlscontext_mule.go
@@ -207,6 +207,10 @@ func resourceSecretGroupTlsContextMuleRead(ctx context.Context, d *schema.Resour
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_tlscontext_securityfabric.go
+++ b/anypoint/resource_secretgroup_tlscontext_securityfabric.go
@@ -488,6 +488,10 @@ func resourceSecretGroupTlsContextSFRead(ctx context.Context, d *schema.Resource
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_secretgroup_truststore.go
+++ b/anypoint/resource_secretgroup_truststore.go
@@ -200,6 +200,10 @@ func resourceSecretGroupTruststoreRead(ctx context.Context, d *schema.ResourceDa
 	authctx := getSgTruststoreAuthCtx(ctx, &pco)
 	res, httpr, err := pco.sgtruststoreclient.DefaultApi.GetSecretGroupTruststoreDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_team.go
+++ b/anypoint/resource_team.go
@@ -136,6 +136,10 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	//request roles
 	res, httpr, err := pco.teamclient.DefaultAPI.GetTeam(authctx, orgid, teamid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_team_groupmappings.go
+++ b/anypoint/resource_team_groupmappings.go
@@ -198,6 +198,10 @@ func resourceTeamGroupMappingsRead(ctx context.Context, d *schema.ResourceData, 
 	//request get
 	res, httpr, err := pco.teamgroupmappingsclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdGroupmappingsGet(authctx, orgid, teamid).Limit(500).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_team_member.go
+++ b/anypoint/resource_team_member.go
@@ -143,6 +143,10 @@ func resourceTeamMemberRead(ctx context.Context, d *schema.ResourceData, m any) 
 	//request members
 	res, httpr, err := pco.teammembersclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdMembersGet(authctx, orgid, teamid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_team_roles.go
+++ b/anypoint/resource_team_roles.go
@@ -139,6 +139,10 @@ func resourceTeamRolesRead(ctx context.Context, d *schema.ResourceData, m any) d
 	//perform request
 	res, httpr, err := pco.teamrolesclient.DefaultAPI.GetTeamRoles(authctx, orgid, teamid).Limit(500).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_user.go
+++ b/anypoint/resource_user.go
@@ -214,6 +214,10 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	//perform request
 	res, httpr, err := pco.userclient.DefaultApi.OrganizationsOrgIdUsersUserIdGet(authctx, orgid, userid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_user_rolegroup.go
+++ b/anypoint/resource_user_rolegroup.go
@@ -155,6 +155,10 @@ func resourceUserRolegroupRead(ctx context.Context, d *schema.ResourceData, m an
 		diags = append(diags, errDiags...)
 		return diags
 	}
+	if rg == nil {
+		d.SetId("")
+		return nil
+	}
 	//process data
 	rolegroup := flattenUserRolegroupData(rg)
 	//save in data source schema

--- a/anypoint/resource_vpc.go
+++ b/anypoint/resource_vpc.go
@@ -212,6 +212,10 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	//perform request
 	res, httpr, err := pco.vpcclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdGet(authctx, orgid, vpcid).Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()

--- a/anypoint/resource_vpn.go
+++ b/anypoint/resource_vpn.go
@@ -236,6 +236,10 @@ func resourceVPNRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	req := pco.vpnclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdIpsecVpnIdGet(authctx, orgid, vpcid, vpnid)
 	res, httpr, err := req.Execute()
 	if err != nil {
+		if httpr != nil && httpr.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		var details string
 		if httpr != nil && httpr.StatusCode >= 400 {
 			defer httpr.Body.Close()


### PR DESCRIPTION
## Summary

- Wraps every `resource_*.go` Read function with a 404 short-circuit (`d.SetId("") + return nil`) so resources deleted outside Terraform get marked for recreation instead of crashing.
- Fixes a latent `httpr.StatusCode` nil-deref in `resource_secretgroup_keystore.go` (outer condition accessed `httpr.StatusCode` without a nil guard).
- `user_rolegroup` reuses a search helper that returns `nil` on not-found; added a nil-check on the result rather than touching the shared helper.

## Related

- Closes: #17

## Type of change

- [x] Bug fix in existing resource / data source

## Checklist

### Code

- [x] Structured `diag.Diagnostic` preserved; only the 404 short-circuit was inserted at the top of each `if err != nil` block.
- [x] `make build` passes.
- [x] `go vet ./...` clean.

### Verification

- [x] `make install` against local provider.
- [x] Playground apply of a sandbox `anypoint_env`, then simulated external deletion via state surgery (rewrote `id` to a non-existent UUID, bumped serial, `state push`), then `terraform plan` → Terraform proposes `+ create` (graceful recreate). Pre-fix would have crashed on the Read.

## Notes for reviewer

- 43 resource files touched; the change is mechanically uniform except in three places:
  - `resource_secretgroup_keystore.go` — replaced the buggy outer `if err != nil && httpr.StatusCode >= 400` (nil-deref risk) with the standard `if err != nil { ... }` form so the 404 check sits inside.
  - `resource_user_rolegroup.go` — added a `if rg == nil { d.SetId(""); return nil }` after the shared `searchUserRolegroup` call.
  - `resource_private_space_transit_gateway.go`, `resource_fabrics_associations.go`, `resource_team_groupmappings.go` — list-style Reads. 404 added on the err path to catch the parent (private space / fabrics / team) being deleted.
- Collection/list Reads where 404 means "parent gone" are guarded; the existing "manual search → not in list → SetId('')" path in TGW is unchanged.