### PR TITLE
fix(bg): flip non-writable entitlement fields to Computed (#75)

### DIFF
--- a/anypoint/data_source_bg.go
+++ b/anypoint/data_source_bg.go
@@ -838,9 +838,11 @@ func getBGCoreAttributes() []string {
 
 func getBGUpdatableAttributes() []string {
 	attributes := [...]string{
-		"name", "owner_id", "entitlements_createenvironments", "entitlements_createsuborgs",
-		"entitlements_globaldeployment", "entitlements_vcoresproduction_assigned", "entitlements_vcoressandbox_assigned",
-		"entitlements_vcoresdesign_assigned", "entitlements_vpcs_assigned", "entitlements_loadbalancer_assigned", "entitlements_vpns_assigned",
+		"name", "owner_id", "session_timeout", "is_federated",
+		"entitlements_createenvironments", "entitlements_createsuborgs", "entitlements_globaldeployment",
+		"entitlements_vcoresproduction_assigned", "entitlements_vcoressandbox_assigned", "entitlements_vcoresdesign_assigned",
+		"entitlements_vpcs_assigned", "entitlements_vpns_assigned", "entitlements_staticips_assigned",
+		"entitlements_loadbalancer_assigned",
 	}
 	return attributes[:]
 }

--- a/anypoint/resource_bg.go
+++ b/anypoint/resource_bg.go
@@ -307,145 +307,88 @@ func resourceBG() *schema.Resource {
 			},
 			"entitlements_workerloggingoverride_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether the loggin override on workers is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether the logging override on workers is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_mqmessages_base": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     50000000,
-				Description: "The number of basic MQ messages assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "50000000") // default value of integers if not set is 50000000
-				},
+				Computed:    true,
+				Description: "The number of basic MQ messages assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_mqmessages_addon": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of MQ messages addons assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of MQ messages addons assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_mqrequests_base": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     100000000,
-				Description: "The number of MQ requests base assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "100000000") // default value of integers if not set is 100000000
-				},
+				Computed:    true,
+				Description: "The number of MQ requests base assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_mqrequests_addon": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of MQ requests addon assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of MQ requests addon assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_objectstorerequestunits_base": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of object store requests unists base for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of object store request units base for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_objectstorerequestunits_addon": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of object store requests units addon for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of object store request units addon for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_objectstorekeys_base": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of object store keys base for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of object store keys base for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_objectstorekeys_addon": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of object store keys addon for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of object store keys addon for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_mqadvancedfeatures_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether the Anypoint MQ advanced features are enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether the Anypoint MQ advanced features are enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_gateways_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     0,
-				Description: "The number of gateways assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of gateways assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_designcenter_api": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether te design center api is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether the design center api is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_designcenter_mozart": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether the design center mozart is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether the design center mozart is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_partnersproduction_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of partners production vcores assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of partners production vcores assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_partnerssandbox_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of partners sandbox vcores assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of partners sandbox vcores assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_tradingpartnersproduction_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of traded partners production vcores assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of trading partners production vcores assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_tradingpartnerssandbox_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The number of traded partners sandbox vcores assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of trading partners sandbox vcores assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_loadbalancer_assigned": {
 				Type:        schema.TypeInt,
@@ -463,225 +406,138 @@ func resourceBG() *schema.Resource {
 			},
 			"entitlements_externalidentity": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether an external identity provider (IDP) was assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether an external identity provider (IDP) was assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_autoscaling": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether autoscaling is enabled for this organization",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether autoscaling is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_armalerts": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether arm alerts are enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether arm alerts are enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_apis_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "whether APIs are enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether APIs are enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_apimonitoring_schedules": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     5,
-				Description: "The number of api monitoring schedules for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "5") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of api monitoring schedules for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_apicommunitymanager_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether api community manager is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether api community manager is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_monitoringcenter_productsku": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     3,
-				Description: "The number of monitoring center products sku for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "3") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of monitoring center products sku for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_apiquery_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether api queries are enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether api queries are enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_apiquery_productsku": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1,
-				Description: "The number of api query product sku for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "1") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of api query product sku for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_apiqueryc360_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether api query C360 is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether api query C360 is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_anggovernance_level": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "0") // default value of integers if not set is 0
-				},
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ANG governance level for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_crowd_hideapimanagerdesigner": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the Crowd hide API Manager designer entitlement is enabled. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_crowd_hideformerapiplatform": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the Crowd hide former API platform entitlement is enabled. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_crowd_environments": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the Crowd environments entitlement is enabled. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_cam_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether cam is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether CAM is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_exchange2_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether exchange v2 is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether Exchange v2 is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_crowdselfservicemigration_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether crow self service migration is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether Crowd self-service migration is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_kpidashboard_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether KPI dashboard is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether the KPI dashboard is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_pcf": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether PCF is included for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether PCF is included for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_appviz": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether the app vizualize if enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "flase") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether the application visualization entitlement is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_runtimefabric": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether Runtime Fabrics (RTF) is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true")
-				},
+				Computed:    true,
+				Description: "Whether Runtime Fabric (RTF) is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_anypointsecuritytokenization_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "whether Anypoint securirty tokenization is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether Anypoint Security tokenization is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_anypointsecurityedgepolicies_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether Anypoint security edge policies is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether Anypoint Security edge policies are enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_runtimefabriccloud_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Whether Runtime Fabrics (RTF) is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "true") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether Runtime Fabric Cloud is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_servicemesh_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether Service Mesh is enabled for this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "false") // default value of bool if not set is false
-				},
+				Computed:    true,
+				Description: "Whether Service Mesh is enabled for this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_messaging_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1,
-				Description: "The number of messaging assigned to this organization.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "1") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of messaging units assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_workerclouds_assigned": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1,
-				Description: "The number of worker clouds assigned to this organization",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return DiffSuppressFunc4OptionalPrimitives(k, old, new, d, "1") // default value of integers if not set is 0
-				},
+				Computed:    true,
+				Description: "The number of worker clouds assigned to this organization. Read-only — tied to the organization's subscription.",
 			},
 			"entitlements_workerclouds_reassigned": {
 				Type:        schema.TypeInt,

--- a/docs/data-sources/exchange_asset.md
+++ b/docs/data-sources/exchange_asset.md
@@ -47,6 +47,7 @@ output "petstore_status" {
 
 - `attributes` (List of Object) (see [below for nested schema](#nestedatt--attributes))
 - `categories` (List of Object) (see [below for nested schema](#nestedatt--categories))
+- `classifier` (String)
 - `contact_email` (String)
 - `contact_name` (String)
 - `created_at` (String)

--- a/docs/resources/bg.md
+++ b/docs/resources/bg.md
@@ -41,60 +41,16 @@ resource "anypoint_bg" "bg" {
 
 ### Optional
 
-- `entitlements_anggovernance_level` (Number)
-- `entitlements_anypointsecurityedgepolicies_enabled` (Boolean) Whether Anypoint security edge policies is enabled for this organization.
-- `entitlements_anypointsecuritytokenization_enabled` (Boolean) whether Anypoint securirty tokenization is enabled for this organization.
-- `entitlements_apicommunitymanager_enabled` (Boolean) Whether api community manager is enabled for this organization.
-- `entitlements_apimonitoring_schedules` (Number) The number of api monitoring schedules for this organization.
-- `entitlements_apiquery_enabled` (Boolean) Whether api queries are enabled for this organization.
-- `entitlements_apiquery_productsku` (Number) The number of api query product sku for this organization.
-- `entitlements_apiqueryc360_enabled` (Boolean) Whether api query C360 is enabled for this organization.
-- `entitlements_apis_enabled` (Boolean) whether APIs are enabled for this organization.
-- `entitlements_appviz` (Boolean) Whether the app vizualize if enabled for this organization.
-- `entitlements_armalerts` (Boolean) Whether arm alerts are enabled for this organization.
-- `entitlements_autoscaling` (Boolean) Whether autoscaling is enabled for this organization
-- `entitlements_cam_enabled` (Boolean) Whether cam is enabled for this organization.
 - `entitlements_createenvironments` (Boolean) Whether this organization can have additional environments.
 - `entitlements_createsuborgs` (Boolean) Whether this organization can create sub organizations (descendants).
-- `entitlements_crowd_environments` (Boolean)
-- `entitlements_crowd_hideapimanagerdesigner` (Boolean)
-- `entitlements_crowd_hideformerapiplatform` (Boolean)
-- `entitlements_crowdselfservicemigration_enabled` (Boolean) Whether crow self service migration is enabled for this organization.
-- `entitlements_designcenter_api` (Boolean) Whether te design center api is enabled for this organization.
-- `entitlements_designcenter_mozart` (Boolean) Whether the design center mozart is enabled for this organization.
-- `entitlements_exchange2_enabled` (Boolean) Whether exchange v2 is enabled for this organization.
-- `entitlements_externalidentity` (Boolean) Whether an external identity provider (IDP) was assigned to this organization.
-- `entitlements_gateways_assigned` (Number) The number of gateways assigned to this organization.
 - `entitlements_globaldeployment` (Boolean) Whether this organization can have global deployments.
-- `entitlements_kpidashboard_enabled` (Boolean) Whether KPI dashboard is enabled for this organization.
 - `entitlements_loadbalancer_assigned` (Number) The number of dedicated load balancers (DLB) assigned to this organization.
-- `entitlements_messaging_assigned` (Number) The number of messaging assigned to this organization.
-- `entitlements_monitoringcenter_productsku` (Number) The number of monitoring center products sku for this organization.
-- `entitlements_mqadvancedfeatures_enabled` (Boolean) Whether the Anypoint MQ advanced features are enabled for this organization.
-- `entitlements_mqmessages_addon` (Number) The number of MQ messages addons assigned to this organization.
-- `entitlements_mqmessages_base` (Number) The number of basic MQ messages assigned to this organization.
-- `entitlements_mqrequests_addon` (Number) The number of MQ requests addon assigned to this organization.
-- `entitlements_mqrequests_base` (Number) The number of MQ requests base assigned to this organization.
-- `entitlements_objectstorekeys_addon` (Number) The number of object store keys addon for this organization.
-- `entitlements_objectstorekeys_base` (Number) The number of object store keys base for this organization.
-- `entitlements_objectstorerequestunits_addon` (Number) The number of object store requests units addon for this organization.
-- `entitlements_objectstorerequestunits_base` (Number) The number of object store requests unists base for this organization.
-- `entitlements_partnersproduction_assigned` (Number) The number of partners production vcores assigned to this organization.
-- `entitlements_partnerssandbox_assigned` (Number) The number of partners sandbox vcores assigned to this organization.
-- `entitlements_pcf` (Boolean) Whether PCF is included for this organization.
-- `entitlements_runtimefabric` (Boolean) Whether Runtime Fabrics (RTF) is enabled for this organization.
-- `entitlements_runtimefabriccloud_enabled` (Boolean) Whether Runtime Fabrics (RTF) is enabled for this organization.
-- `entitlements_servicemesh_enabled` (Boolean) Whether Service Mesh is enabled for this organization.
 - `entitlements_staticips_assigned` (Number) The number of static IPs assigned to this organization.
-- `entitlements_tradingpartnersproduction_assigned` (Number) The number of traded partners production vcores assigned to this organization.
-- `entitlements_tradingpartnerssandbox_assigned` (Number) The number of traded partners sandbox vcores assigned to this organization.
 - `entitlements_vcoresdesign_assigned` (Number) The number of design vcores assigned to this organization.
 - `entitlements_vcoresproduction_assigned` (Number) The number of production vcores assigned to this organization.
 - `entitlements_vcoressandbox_assigned` (Number) The number of sandbox vcores assigned to this organization.
 - `entitlements_vpcs_assigned` (Number) The number of VPCs assigned to this organization.
 - `entitlements_vpns_assigned` (Number) The number of VPNs assigned to this organization.
-- `entitlements_workerclouds_assigned` (Number) The number of worker clouds assigned to this organization
-- `entitlements_workerloggingoverride_enabled` (Boolean) Whether the loggin override on workers is enabled for this organization.
 - `is_federated` (Boolean) Whether this organization is federated.
 - `last_updated` (String) The last time this resource has been updated locally.
 - `session_timeout` (Number) The organization's session timeout
@@ -104,17 +60,61 @@ resource "anypoint_bg" "bg" {
 - `client_id` (String) The organization client id.
 - `created_at` (String) The time when this organization was created.
 - `domain` (String) The organization's domain
+- `entitlements_anggovernance_level` (Number) The ANG governance level for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_anypointsecurityedgepolicies_enabled` (Boolean) Whether Anypoint Security edge policies are enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_anypointsecuritytokenization_enabled` (Boolean) Whether Anypoint Security tokenization is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_apicommunitymanager_enabled` (Boolean) Whether api community manager is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_apimonitoring_schedules` (Number) The number of api monitoring schedules for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_apiquery_enabled` (Boolean) Whether api queries are enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_apiquery_productsku` (Number) The number of api query product sku for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_apiqueryc360_enabled` (Boolean) Whether api query C360 is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_apis_enabled` (Boolean) Whether APIs are enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_appviz` (Boolean) Whether the application visualization entitlement is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_armalerts` (Boolean) Whether arm alerts are enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_autoscaling` (Boolean) Whether autoscaling is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_cam_enabled` (Boolean) Whether CAM is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_crowd_environments` (Boolean) Whether the Crowd environments entitlement is enabled. Read-only — tied to the organization's subscription.
+- `entitlements_crowd_hideapimanagerdesigner` (Boolean) Whether the Crowd hide API Manager designer entitlement is enabled. Read-only — tied to the organization's subscription.
+- `entitlements_crowd_hideformerapiplatform` (Boolean) Whether the Crowd hide former API platform entitlement is enabled. Read-only — tied to the organization's subscription.
+- `entitlements_crowdselfservicemigration_enabled` (Boolean) Whether Crowd self-service migration is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_designcenter_api` (Boolean) Whether the design center api is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_designcenter_mozart` (Boolean) Whether the design center mozart is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_exchange2_enabled` (Boolean) Whether Exchange v2 is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_externalidentity` (Boolean) Whether an external identity provider (IDP) was assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_gateways_assigned` (Number) The number of gateways assigned to this organization. Read-only — tied to the organization's subscription.
 - `entitlements_hybridautodiscoverproperties` (Boolean) Whether this organization has hybrid auto-discovery properties enabled
 - `entitlements_hybridenabled` (Boolean) Whether this organization has hybrid enabled.
 - `entitlements_hybridinsight` (Boolean) Whether this organization has hybrid insight.
+- `entitlements_kpidashboard_enabled` (Boolean) Whether the KPI dashboard is enabled for this organization. Read-only — tied to the organization's subscription.
 - `entitlements_loadbalancer_reassigned` (Number) The number of dedicated load balancers (DLB) reassigned to this organization.
+- `entitlements_messaging_assigned` (Number) The number of messaging units assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_monitoringcenter_productsku` (Number) The number of monitoring center products sku for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_mqadvancedfeatures_enabled` (Boolean) Whether the Anypoint MQ advanced features are enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_mqmessages_addon` (Number) The number of MQ messages addons assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_mqmessages_base` (Number) The number of basic MQ messages assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_mqrequests_addon` (Number) The number of MQ requests addon assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_mqrequests_base` (Number) The number of MQ requests base assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_objectstorekeys_addon` (Number) The number of object store keys addon for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_objectstorekeys_base` (Number) The number of object store keys base for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_objectstorerequestunits_addon` (Number) The number of object store request units addon for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_objectstorerequestunits_base` (Number) The number of object store request units base for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_partnersproduction_assigned` (Number) The number of partners production vcores assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_partnerssandbox_assigned` (Number) The number of partners sandbox vcores assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_pcf` (Boolean) Whether PCF is included for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_runtimefabric` (Boolean) Whether Runtime Fabric (RTF) is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_runtimefabriccloud_enabled` (Boolean) Whether Runtime Fabric Cloud is enabled for this organization. Read-only — tied to the organization's subscription.
+- `entitlements_servicemesh_enabled` (Boolean) Whether Service Mesh is enabled for this organization. Read-only — tied to the organization's subscription.
 - `entitlements_staticips_reassigned` (Number) The number of static IPs reassigned to this organization.
+- `entitlements_tradingpartnersproduction_assigned` (Number) The number of trading partners production vcores assigned to this organization. Read-only — tied to the organization's subscription.
+- `entitlements_tradingpartnerssandbox_assigned` (Number) The number of trading partners sandbox vcores assigned to this organization. Read-only — tied to the organization's subscription.
 - `entitlements_vcoresdesign_reassigned` (Number) The number of design vcores reassigned to this organization.
 - `entitlements_vcoresproduction_reassigned` (Number) The number of production vcores reassigned to this organization.
 - `entitlements_vcoressandbox_reassigned` (Number) The number of sandbox vcores reassigned to this organization.
 - `entitlements_vpcs_reassigned` (Number) The number of VPCs reassigned to this organization.
 - `entitlements_vpns_reassigned` (Number) The number of VPNs reassigned to this organization.
+- `entitlements_workerclouds_assigned` (Number) The number of worker clouds assigned to this organization. Read-only — tied to the organization's subscription.
 - `entitlements_workerclouds_reassigned` (Number) The number of worker clouds reassigned to this organization
+- `entitlements_workerloggingoverride_enabled` (Boolean) Whether the logging override on workers is enabled for this organization. Read-only — tied to the organization's subscription.
 - `environments` (List of Object) The organization's list of environments (see [below for nested schema](#nestedatt--environments))
 - `id` (String) This organization's unique id generated by the anypoint plaform
 - `idprovider_id` (String) The identity provider if of this organization

--- a/docs/resources/connected_app.md
+++ b/docs/resources/connected_app.md
@@ -93,7 +93,7 @@ resource "anypoint_connected_app" "my_conn_app_behalf_of_user" {
 - `public_keys` (List of String) Application public key (PEM format). Used to validate JWT authorization grants.
 				Required when grant type jwt-bearer is selected.
 - `redirect_uris` (List of String) Configure which URIs users may be directed to after authorization
-- `scope` (Block List) The scopes this connected app has authorization to work on (see [below for nested schema](#nestedblock--scope))
+- `scope` (Block List) The scopes this connected app has authorization to work on. For `client_credentials` connected apps, scopes are compared as an unordered set, so reordering scope blocks does not produce a diff. (see [below for nested schema](#nestedblock--scope))
 - `secret` (String, Sensitive) The secret of the connected app.
 
 ### Read-Only

--- a/docs/resources/exchange_asset.md
+++ b/docs/resources/exchange_asset.md
@@ -68,8 +68,8 @@ resource "anypoint_exchange_asset" "external_http_api" {
 - `main_file` (String) The main file of the asset package. Required for raml, raml-fragment, oas, wsdl. Write-only.
 - `metadata` (String) Stringified JSON object describing asset projectId, branchId and commitId (Design Center metadata). Write-only.
 - `original_format_version` (String) The version of the API spec format (e.g. '2.0' for OAS 2.0). Write-only.
-- `strict_package` (Boolean) Whether the asset package is immutable (X-Strict-Package header).
-- `tags` (List of String) Tags to associate with the asset. The provider stringifies the list before sending.
+- `strict_package` (Boolean) Whether the asset package is immutable (X-Strict-Package header). Write-only: defaults to false, the Exchange API never returns it.
+- `tags` (List of String) Tags to associate with the asset. The provider stringifies the list before sending. Write-only.
 
 ### Read-Only
 


### PR DESCRIPTION
## Summary

- Flip ~44 non-writable `entitlements_*` fields on `anypoint_bg` from `Optional` to `Computed`. They were never serialized into the Create/Update payload, so user-supplied values were silently ignored. Plans now fail at parse time instead of pretending to work.
- The writable ten (`entitlements_createenvironments`, `_createsuborgs`, `_globaldeployment`, `_vcoresproduction_assigned`, `_vcoressandbox_assigned`, `_vcoresdesign_assigned`, `_vpcs_assigned`, `_vpns_assigned`, `_loadbalancer_assigned`, `_staticips_assigned`) stay Optional.
- Fix a separate latent bug in `getBGUpdatableAttributes`: it was missing `entitlements_staticips_assigned`, `session_timeout`, and `is_federated`, so Update couldn't detect changes to these writable fields. They are now in the list.
- Regenerate docs (`docs/resources/bg.md` and three drifted files from earlier PRs).

## Related

- Closes: #75
- Background: #16

## Type of change

- [x] Bug fix in existing resource / data source
- [x] Documentation only (regenerated via `tfplugindocs`)

## Breaking change

Yes — but only for configurations that were already broken. Any HCL like

```hcl
resource \"anypoint_bg\" \"x\" {
  ...
  entitlements_messaging_assigned        = 5
  entitlements_mqadvancedfeatures_enabled = true
  entitlements_mqmessages_base            = 1
}
```

will now fail with \"Can't configure a value for X\" instead of silently no-oping. Migration: remove those lines. The values come back via Read on the next refresh.

## Test plan

- [x] `make build` clean.
- [x] `data \"anypoint_bg\"` against an existing org returns every flipped field correctly (`messaging_assigned=1`, `mqadvancedfeatures_enabled=true`, `mqmessages_base=50000000`, `mqrequests_base=100000000`, etc.).
- [x] `tfplugindocs generate` ran; `docs/resources/bg.md` shows the flipped fields under Read-Only.
- [x] `grep -n \"replace \" go.mod` → no `anypoint-client-go` entries.

## Notes

The writable / non-writable split was determined by reading `newEntitlementsFromD` in `resource_bg.go` — only the fields that flow into the OAS-generated request body are kept Optional. If any of the now-Computed fields gain platform support for writes in the future, they can be flipped back individually.