### PR TITLE
fix(bg): retry transient errors on concurrent for_each (closes #54)

### DIFF
--- a/anypoint/resource_bg.go
+++ b/anypoint/resource_bg.go
@@ -3,6 +3,7 @@ package anypoint
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -643,21 +644,15 @@ func resourceBGCreate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	pco := m.(ProviderConfOutput)
 	authctx := getBGAuthCtx(ctx, &pco)
 	body := newBGPostBody(d)
-	//perform request
-	res, httpr, err := pco.orgclient.DefaultApi.OrganizationsPost(authctx).BGPostReqBody(*body).Execute()
+	//perform request with retry on transient parent-org contention (issue #54)
+	res, httpr, err := retryTransient(ctx, "bg create", func() (org.BGCore, *http.Response, error) {
+		return pco.orgclient.DefaultApi.OrganizationsPost(authctx).BGPostReqBody(*body).Execute()
+	})
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Create Business Group",
-			Detail:   details,
+			Detail:   extractAPIErrorDetail(err, httpr),
 		})
 		return diags
 	}
@@ -717,20 +712,14 @@ func resourceBGUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	//check for updates
 	if d.HasChanges(getBGUpdatableAttributes()...) {
 		body := newBGPutBody(d)
-		_, httpr, err := pco.orgclient.DefaultApi.OrganizationsOrgIdPut(authctx, orgid).BGPutReqBody(*body).Execute()
+		_, httpr, err := retryTransient(ctx, "bg update "+orgid, func() (org.BGCore, *http.Response, error) {
+			return pco.orgclient.DefaultApi.OrganizationsOrgIdPut(authctx, orgid).BGPutReqBody(*body).Execute()
+		})
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update business group " + orgid,
-				Detail:   details,
+				Detail:   extractAPIErrorDetail(err, httpr),
 			})
 			return diags
 		}
@@ -747,20 +736,14 @@ func resourceBGDelete(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	orgid := d.Id()
 	authctx := getBGAuthCtx(ctx, &pco)
 	//perform request
-	_, httpr, err := pco.orgclient.DefaultApi.OrganizationsOrgIdDelete(authctx, orgid).Execute()
+	_, httpr, err := retryTransient(ctx, "bg delete "+orgid, func() (map[string]interface{}, *http.Response, error) {
+		return pco.orgclient.DefaultApi.OrganizationsOrgIdDelete(authctx, orgid).Execute()
+	})
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete Business Group",
-			Detail:   details,
+			Detail:   extractAPIErrorDetail(err, httpr),
 		})
 		return diags
 	}

--- a/anypoint/util.go
+++ b/anypoint/util.go
@@ -1,14 +1,20 @@
 package anypoint
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"log"
 	"math"
+	"math/rand"
+	"net/http"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -327,4 +333,79 @@ func getSchemaKeys(m map[string]*schema.Schema) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// extractAPIErrorDetail surfaces the API error body. The openapi-generator
+// client drains httpr.Body inside Execute() and caches it on
+// GenericOpenAPIError, so reading httpr.Body again returns nothing — must
+// read err.Body() instead. The httpr fallback exists only for the rare path
+// where err is not a generator-generated error.
+func extractAPIErrorDetail(err error, httpr *http.Response) string {
+	if err == nil {
+		return ""
+	}
+	type bodyErr interface{ Body() []byte }
+	if be, ok := err.(bodyErr); ok {
+		if b := be.Body(); len(b) > 0 {
+			if httpr != nil {
+				return fmt.Sprintf("HTTP %d: %s", httpr.StatusCode, string(b))
+			}
+			return string(b)
+		}
+	}
+	if httpr != nil && httpr.StatusCode >= 400 {
+		defer httpr.Body.Close()
+		b, _ := io.ReadAll(httpr.Body)
+		return fmt.Sprintf("HTTP %d: %s", httpr.StatusCode, string(b))
+	}
+	return err.Error()
+}
+
+// isRetryableStatus reports whether an HTTP status indicates a transient
+// server-side condition worth retrying. 409 covers parent-org contention
+// (issue #54); 429 is rate-limit; 5xx is upstream failure.
+func isRetryableStatus(httpr *http.Response) bool {
+	if httpr == nil {
+		return false
+	}
+	s := httpr.StatusCode
+	return s == http.StatusConflict || s == http.StatusTooManyRequests || s >= 500
+}
+
+// retryTransient retries an Anypoint API call on transient server-side
+// errors. The Anypoint Accounts API in particular serializes mutations
+// against shared parent-org records; concurrent for_each operations on
+// sibling resources race and intermittently fail (issue #54). Exponential
+// backoff 250ms → 4s with 50% jitter, capped at 5 attempts. Honors ctx
+// cancellation.
+func retryTransient[T any](ctx context.Context, op string, fn func() (T, *http.Response, error)) (T, *http.Response, error) {
+	const maxAttempts = 5
+	var (
+		zero  T
+		httpr *http.Response
+		err   error
+	)
+	backoff := 250 * time.Millisecond
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		zero, httpr, err = fn()
+		if err == nil || !isRetryableStatus(httpr) {
+			if attempt > 0 {
+				log.Printf("[DEBUG] retryTransient %s: succeeded on attempt %d", op, attempt+1)
+			}
+			return zero, httpr, err
+		}
+		if attempt == maxAttempts-1 {
+			log.Printf("[WARN] retryTransient %s: giving up after %d attempts, last status=%d", op, maxAttempts, httpr.StatusCode)
+			break
+		}
+		sleep := backoff + time.Duration(rand.Int63n(int64(backoff/2)))
+		log.Printf("[DEBUG] retryTransient %s: attempt %d got status=%d, sleeping %s", op, attempt+1, httpr.StatusCode, sleep)
+		select {
+		case <-ctx.Done():
+			return zero, httpr, err
+		case <-time.After(sleep):
+		}
+		backoff *= 2
+	}
+	return zero, httpr, err
 }


### PR DESCRIPTION
## Summary

- Concurrent `for_each` on `anypoint_bg` under one parent intermittently fails — the Anypoint Accounts API serializes mutations against the shared parent-org record and returns **503** (and occasionally 409/429) under contention. Adds a generic `retryTransient[T]` helper to `util.go` and wraps the three `bg` mutating endpoints (Create / Update / Delete).
- Adds `extractAPIErrorDetail` to surface the API body. The openapi-generator client drains `httpr.Body` inside `Execute()` and caches it on `GenericOpenAPIError`; the previous handler read `httpr.Body` again and got nothing, so diagnostics had `Detail=""`.
- Helpers live in `util.go` for future reuse — provider-wide rollout to other resources is intentionally out of scope for this PR (follow-up planned).

## Related

- Closes: #54

## Type of change

- [x] Bug fix in existing resource / data source

## Checklist

### Code

- [x] Resource files follow `AGENTS.md` skeleton.
- [x] `gofmt -w anypoint/` and `goimports -w anypoint/` clean.
- [x] `make build` passes.

### Spec / client dependency

- [x] No spec change. No client module bump.
- [x] `go.mod` has no `replace` directive for `anypoint-client-go/*`.

### Verification

- [x] `make install` against local provider.
- [x] Playground `for_each` apply of 5 sibling BGs under one parent: **previously 2/5 failed with empty `diag.Detail`; now all 5 succeed**. `TF_LOG=DEBUG` shows `retryTransient bg create: attempt 1 got status=503, sleeping ...` then `succeeded on attempt 2`.
- [x] `terraform destroy` clean.

## Notes for reviewer

- **Retry safety**: capped at 5 attempts (~8s worst case). 409 is included in the retryable set because the #54 race likely surfaces as either 503 or 409 — but a true name-conflict 409 is terminal in practice (retry just resurfaces the same error 5x with backoff, total ~8s before failing to the user with the actual body via `extractAPIErrorDetail`). Acceptable trade-off for the race fix.
- **Why scope is `bg` only**: same race likely affects other resources hitting org-shared state, but each resource needs idempotency review before wrapping its Create path. PR2 (extraction rollout, reporting-only, zero behavior change) and PR3 (retry rollout, per-resource audit) are queued separately.
- **Generic helper**: uses Go generics. Repo is on Go 1.20+, so safe.
- **Empty `diag.Detail` bug is provider-wide**: every `resource_*.go` reads `httpr.Body` after `Execute()` (257 sites across 118 files). This PR fixes only `bg`; the rest land in PR2.