### PR TITLE
refactor: replace inline httpr.Body error extraction with shared helper

### DIFF
--- a/anypoint/data_source_ame.go
+++ b/anypoint/data_source_ame.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -129,14 +128,7 @@ func dataSourceAMERead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//Executing Request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get AMEs",

--- a/anypoint/data_source_amq.go
+++ b/anypoint/data_source_amq.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -157,14 +156,7 @@ func dataSourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//Executing Request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get AMQs",

--- a/anypoint/data_source_api_instance_sla_tiers.go
+++ b/anypoint/data_source_api_instance_sla_tiers.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -155,14 +154,7 @@ func dataSourceApiInstanceSlaTiersRead(ctx context.Context, d *schema.ResourceDa
 	res, httpr, err := pco.apimtierclient.DefaultAPI.GetApiInstanceTiers(authctx, orgid, envid, apiid).
 		Limit(limit).Offset(offset).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to list SLA tiers for api " + apiid,

--- a/anypoint/data_source_apim.go
+++ b/anypoint/data_source_apim.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -410,14 +409,7 @@ func dataSourceApimRead(ctx context.Context, d *schema.ResourceData, m any) diag
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get api manager instances for org " + orgid + " and env " + envid,

--- a/anypoint/data_source_apim_instance.go
+++ b/anypoint/data_source_apim_instance.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"sort"
 	"strings"
@@ -417,14 +416,7 @@ func dataSourceApimInstanceRead(ctx context.Context, d *schema.ResourceData, m a
 	//perform request
 	res, httpr, err := pco.apimclient.DefaultApi.GetApimInstanceDetails(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get API manager instance",
@@ -466,14 +458,7 @@ func readApimInstanceUpstreamsOnly(ctx context.Context, d *schema.ResourceData, 
 	//perform request
 	res, httpr, err := pco.apimupstreamclient.DefaultApi.GetApimInstanceUpstreams(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get API manager instance " + id + " upstreams",

--- a/anypoint/data_source_apim_instance_policies.go
+++ b/anypoint/data_source_apim_instance_policies.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -131,14 +130,7 @@ func dataSourceApimInstancePoliciesRead(ctx context.Context, d *schema.ResourceD
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicies(authctx, orgid, envid, apimid).FullInfo(false).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get policies for api " + apimid,

--- a/anypoint/data_source_apim_instance_policy.go
+++ b/anypoint/data_source_apim_instance_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 
@@ -126,14 +125,7 @@ func dataSourceApimInstancePolicyRead(ctx context.Context, d *schema.ResourceDat
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get policy " + id + " for api " + apimid,

--- a/anypoint/data_source_apim_instance_upstreams.go
+++ b/anypoint/data_source_apim_instance_upstreams.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"sort"
 	"strconv"
 	"time"
@@ -115,14 +114,7 @@ func dataSourceApimInstanceUpstreamsRead(ctx context.Context, d *schema.Resource
 	//perform request
 	res, httpr, err := pco.apimupstreamclient.DefaultApi.GetApimInstanceUpstreams(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get API manager instance " + id + " upstreams",

--- a/anypoint/data_source_app_deployment_v2.go
+++ b/anypoint/data_source_app_deployment_v2.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -605,14 +604,7 @@ func dataSourceAppDeploymentV2Read(ctx context.Context, d *schema.ResourceData, 
 	//execut request
 	res, httpr, err := pco.appmanagerclient.DefaultApi.GetDeploymentById(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get deployment for org " + orgid + " and env " + envid + " with id " + id,

--- a/anypoint/data_source_app_deployments_v2.go
+++ b/anypoint/data_source_app_deployments_v2.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -161,14 +160,7 @@ func dataSourceAppDeploymentsV2Read(ctx context.Context, d *schema.ResourceData,
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get deployments for org " + orgid + " and env " + envid,

--- a/anypoint/data_source_bg.go
+++ b/anypoint/data_source_bg.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -581,14 +580,7 @@ func dataSourceBGRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	//perform request
 	res, httpr, err := pco.orgclient.DefaultApi.OrganizationsOrgIdGet(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Business Group",

--- a/anypoint/data_source_connected_app.go
+++ b/anypoint/data_source_connected_app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -143,14 +142,7 @@ func dataSourceConnectedAppRead(ctx context.Context, d *schema.ResourceData, m a
 	//request connected app
 	res, httpr, err := pco.connectedappclient.DefaultApi.GetConnectedApp(authctx, orgid, connappid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read connected-app " + connappid,
@@ -194,13 +186,7 @@ func readScopesByConnectedAppId(ctx context.Context, orgid string, connappid str
 	limit := 500
 	res, httpr, err := pco.connectedappclient.DefaultApi.GetConnectedAppScopes(authctx, orgid, connappid).Limit(int32(limit)).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 
 		return nil, errors.New(details)
 	}

--- a/anypoint/data_source_connected_apps.go
+++ b/anypoint/data_source_connected_apps.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -195,14 +194,7 @@ func dataSourceConnectedAppsRead(ctx context.Context, d *schema.ResourceData, m 
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get connected-apps for org " + orgid,

--- a/anypoint/data_source_dlb.go
+++ b/anypoint/data_source_dlb.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -262,14 +261,7 @@ func dataSourceDLBRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request dlb
 	res, httpr, err := pco.dlbclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdLoadbalancersDlbIdGet(authctx, orgid, vpcid, dlbid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get DLB " + dlbid,

--- a/anypoint/data_source_dlbs.go
+++ b/anypoint/data_source_dlbs.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -256,14 +255,7 @@ func dataSourceDLBsRead(ctx context.Context, d *schema.ResourceData, m any) diag
 	//request dlb
 	res, httpr, err := pco.dlbclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdLoadbalancersGet(authctx, orgid, vpcid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get DLBs for org " + orgid + " and vpc " + vpcid,

--- a/anypoint/data_source_env.go
+++ b/anypoint/data_source_env.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -59,14 +58,7 @@ func dataSourceENVRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request env
 	res, httpr, err := pco.envclient.DefaultApi.OrganizationsOrgIdEnvironmentsEnvironmentIdGet(authctx, orgid, envid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get ENV",

--- a/anypoint/data_source_exchange_policy_template.go
+++ b/anypoint/data_source_exchange_policy_template.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -279,14 +278,7 @@ func dataSourceExchangePolicyTemplateRead(ctx context.Context, d *schema.Resourc
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.GetOrgExchangePolicyTemplateDetails(authctx, orgid, groupid, id, version).IncludeAllVersions(include_all_versions).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get policy template " + id,

--- a/anypoint/data_source_exchange_policy_templates.go
+++ b/anypoint/data_source_exchange_policy_templates.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -250,14 +249,7 @@ func dataSourceExchangePolicyTemplatesRead(ctx context.Context, d *schema.Resour
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get exchange policy templates for org " + orgid,

--- a/anypoint/data_source_fabrics.go
+++ b/anypoint/data_source_fabrics.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -288,14 +287,7 @@ func dataSourceFabricsRead(ctx context.Context, d *schema.ResourceData, m any) d
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetFabrics(authctx, orgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get fabrics " + id,

--- a/anypoint/data_source_fabrics_associations.go
+++ b/anypoint/data_source_fabrics_associations.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -69,14 +68,7 @@ func dataSourceFabricsAssociationsRead(ctx context.Context, d *schema.ResourceDa
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetFabricsAssociations(authctx, orgid, fabricsId).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get fabrics associations",

--- a/anypoint/data_source_fabrics_health.go
+++ b/anypoint/data_source_fabrics_health.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -130,14 +129,7 @@ func dataSourceFabricsHealthRead(ctx context.Context, d *schema.ResourceData, m 
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetFabricsHealth(authctx, orgid, fabricsid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get fabrics health metrics",

--- a/anypoint/data_source_fabrics_helm_repo.go
+++ b/anypoint/data_source_fabrics_helm_repo.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -52,14 +51,7 @@ func dataSourceFabricsHelmRepoPropsRead(ctx context.Context, d *schema.ResourceD
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetFabricsHelmRepoProps(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get fabrics helm repository props",

--- a/anypoint/data_source_fabrics_list.go
+++ b/anypoint/data_source_fabrics_list.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -172,14 +171,7 @@ func dataSourceAllFabricsRead(ctx context.Context, d *schema.ResourceData, m any
 	//perform request
 	res, httpr, err := pco.rtfclient.DefaultApi.GetAllFabrics(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get fabrics list",

--- a/anypoint/data_source_flexgateway_registration_token.go
+++ b/anypoint/data_source_flexgateway_registration_token.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -45,14 +44,7 @@ func dataSourceFlexGatewayRegistrationTokenRead(ctx context.Context, d *schema.R
 	//perform request
 	res, httpr, err := pco.flexgatewayclient.DefaultApi.GetFlexGatewayRegistrationToken(authctx, orgid, envid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get flex gateway registration token ",

--- a/anypoint/data_source_flexgateway_target.go
+++ b/anypoint/data_source_flexgateway_target.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -109,14 +108,7 @@ func dataSourceFlexGatewayTargetRead(ctx context.Context, d *schema.ResourceData
 	//perform request
 	res, httpr, err := pco.flexgatewayclient.DefaultApi.GetFlexGatewayTargetById(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get flex gateway target " + id,

--- a/anypoint/data_source_flexgateway_targets.go
+++ b/anypoint/data_source_flexgateway_targets.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -93,14 +92,7 @@ func dataSourceFlexGatewayTargetsRead(ctx context.Context, d *schema.ResourceDat
 	//exec request
 	res, httpr, err := pco.flexgatewayclient.DefaultApi.GetFlexGatewayTargets(authctx, orgid, envid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get flex gateway targets for org " + orgid + " and env " + envid,

--- a/anypoint/data_source_idp.go
+++ b/anypoint/data_source_idp.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -199,14 +198,7 @@ func dataSourceIDPRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	res, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdGet(authctx, orgid, idpid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get IDP " + idpid + " in org " + orgid,

--- a/anypoint/data_source_idps.go
+++ b/anypoint/data_source_idps.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -69,14 +68,7 @@ func dataSourceIDPsRead(ctx context.Context, d *schema.ResourceData, m any) diag
 	//request env
 	res, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersGet(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get IDPs for org " + orgid,

--- a/anypoint/data_source_org_transit_gateways.go
+++ b/anypoint/data_source_org_transit_gateways.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -70,14 +69,7 @@ func dataSourceOrgTransitGatewaysRead(ctx context.Context, d *schema.ResourceDat
 	}
 	list, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to List transit gateways for org " + orgid,

--- a/anypoint/data_source_private_space.go
+++ b/anypoint/data_source_private_space.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -226,14 +225,7 @@ func dataSourcePrivateSpaceRead(ctx context.Context, d *schema.ResourceData, m a
 	//request
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpace(authctx, orgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Private Space for org " + orgid + " and id " + id,

--- a/anypoint/data_source_private_space_iam_roles.go
+++ b/anypoint/data_source_private_space_iam_roles.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -45,14 +44,7 @@ func dataSourcePrivateSpaceIamRolesRead(ctx context.Context, d *schema.ResourceD
 	//request
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceIamRoles(authctx, orgid, private_space_id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Error reading private space iam roles",

--- a/anypoint/data_source_private_space_mulesoft_account.go
+++ b/anypoint/data_source_private_space_mulesoft_account.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -41,14 +40,7 @@ func dataSourcePrivateSpaceMulesoftAccountRead(ctx context.Context, d *schema.Re
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceMulesoftAccount(authctx, orgid, psid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read MuleSoft AWS account for private space " + psid,

--- a/anypoint/data_source_private_space_routes.go
+++ b/anypoint/data_source_private_space_routes.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -47,14 +46,7 @@ func dataSourcePrivateSpaceRoutesRead(ctx context.Context, d *schema.ResourceDat
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	list, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceRoutes(authctx, orgid, psid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read routes for private space " + psid,

--- a/anypoint/data_source_private_space_supported_vpn_configs.go
+++ b/anypoint/data_source_private_space_supported_vpn_configs.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -53,14 +52,7 @@ func dataSourcePrivateSpaceSupportedVpnConfigsRead(ctx context.Context, d *schem
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceSupportedVpnConfigs(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read supported VPN configs for org " + orgid,

--- a/anypoint/data_source_private_space_tlscontext.go
+++ b/anypoint/data_source_private_space_tlscontext.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -323,14 +322,7 @@ func dataSourcePrivateSpaceTlsContextRead(ctx context.Context, d *schema.Resourc
 	//request
 	res, httpr, err := pco.privatespacetlscontextclient.DefaultApi.GetTlsContext(authctx, orgid, private_space_id, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Private Space TLS Context for org " + orgid + " and id " + id,

--- a/anypoint/data_source_private_space_tlscontexts.go
+++ b/anypoint/data_source_private_space_tlscontexts.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -46,14 +45,7 @@ func dataSourcePrivateSpaceTlsContextsRead(ctx context.Context, d *schema.Resour
 	//request
 	res, httpr, err := pco.privatespacetlscontextclient.DefaultApi.GetTlsContexts(authctx, orgid, private_space_id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Private Space TLS Contexts for org " + orgid + " and private space " + private_space_id,

--- a/anypoint/data_source_private_space_transit_gateway.go
+++ b/anypoint/data_source_private_space_transit_gateway.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -54,14 +53,7 @@ func dataSourcePrivateSpaceTransitGatewayRead(ctx context.Context, d *schema.Res
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	list, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceTransitGateways(authctx, orgid, psid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read transit gateway " + tgwid + " for private space " + psid,

--- a/anypoint/data_source_private_space_transit_gateways.go
+++ b/anypoint/data_source_private_space_transit_gateways.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -59,14 +58,7 @@ func dataSourcePrivateSpaceTransitGatewaysRead(ctx context.Context, d *schema.Re
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	list, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceTransitGateways(authctx, orgid, psid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to List transit gateways for private space " + psid,

--- a/anypoint/data_source_private_space_vpn.go
+++ b/anypoint/data_source_private_space_vpn.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -74,14 +73,7 @@ func dataSourcePrivateSpaceVpnRead(ctx context.Context, d *schema.ResourceData, 
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceVpnConnection(authctx, orgid, psid, cid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read vpn connection " + cid + " for private space " + psid,

--- a/anypoint/data_source_private_space_vpns.go
+++ b/anypoint/data_source_private_space_vpns.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -69,14 +68,7 @@ func dataSourcePrivateSpaceVpnsRead(ctx context.Context, d *schema.ResourceData,
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	list, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaceVpnConnections(authctx, orgid, psid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to List vpn connections for private space " + psid,

--- a/anypoint/data_source_private_spaces.go
+++ b/anypoint/data_source_private_spaces.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -71,14 +70,7 @@ func dataSourcePrivateSpacesRead(ctx context.Context, d *schema.ResourceData, m 
 	//request
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.GetPrivateSpaces(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Private Spaces for org " + orgid,

--- a/anypoint/data_source_rolegroup.go
+++ b/anypoint/data_source_rolegroup.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,14 +74,7 @@ func dataSourceRoleGroupRead(ctx context.Context, d *schema.ResourceData, m any)
 	//perform request
 	res, httpr, err := pco.rolegroupclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdGet(authctx, orgid, rolegroupid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get rolegroup",

--- a/anypoint/data_source_rolegroups.go
+++ b/anypoint/data_source_rolegroups.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -99,14 +98,7 @@ func dataSourceRoleGroupsRead(ctx context.Context, d *schema.ResourceData, m any
 	//perform request
 	res, httpr, err := pco.rolegroupclient.DefaultApi.OrganizationsOrgIdRolegroupsGet(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get rolegroups",

--- a/anypoint/data_source_roles.go
+++ b/anypoint/data_source_roles.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -143,14 +142,7 @@ func dataSourceRolesRead(ctx context.Context, d *schema.ResourceData, m any) dia
 	//perform request roles
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Roles",

--- a/anypoint/data_source_secretgroup.go
+++ b/anypoint/data_source_secretgroup.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -92,14 +91,7 @@ func dataSourceSecretGroupRead(ctx context.Context, d *schema.ResourceData, m an
 	//perform request
 	res, httpr, err := pco.secretgroupclient.DefaultApi.GetSecretGroup(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get secret group " + id,

--- a/anypoint/data_source_secretgroup_certificate.go
+++ b/anypoint/data_source_secretgroup_certificate.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -86,14 +85,7 @@ func dataSourceSecretGroupCertificateRead(ctx context.Context, d *schema.Resourc
 	//perform request
 	res, httpr, err := pco.sgcertificateclient.DefaultApi.GetSecretGroupCertificateDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get certificate " + id,

--- a/anypoint/data_source_secretgroup_certificates.go
+++ b/anypoint/data_source_secretgroup_certificates.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -82,14 +81,7 @@ func dataSourceSecretGroupCertificatesRead(ctx context.Context, d *schema.Resour
 	// perform request
 	res, httpr, err := pco.sgcertificateclient.DefaultApi.GetSecretGroupCertificates(authctx, orgid, envid, sgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get certificates for secret-group " + sgid,

--- a/anypoint/data_source_secretgroup_crldistrib_cfgs.go
+++ b/anypoint/data_source_secretgroup_crldistrib_cfgs.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -101,14 +100,7 @@ func dataSourceSecretGroupCrlDistribCfgsRead(ctx context.Context, d *schema.Reso
 	//perform request
 	res, httpr, err := pco.sgcrldistribcfgsclient.DefaultApi.GetSecretGroupCrlDistribCfgsDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get crl-distributor-configs " + id,

--- a/anypoint/data_source_secretgroup_crldistrib_cfgs_list.go
+++ b/anypoint/data_source_secretgroup_crldistrib_cfgs_list.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -77,14 +76,7 @@ func dataSourceSecretGroupCrlDistribCfgsListRead(ctx context.Context, d *schema.
 	//perform request
 	res, httpr, err := pco.sgcrldistribcfgsclient.DefaultApi.GetSecretGroupCrlDistribCfgsList(authctx, orgid, envid, sgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get crl-distributor-configss for secret-group " + sgid,

--- a/anypoint/data_source_secretgroup_keystore.go
+++ b/anypoint/data_source_secretgroup_keystore.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -199,14 +198,7 @@ func dataSourceSecretGroupKeystoreRead(ctx context.Context, d *schema.ResourceDa
 	authctx := getSgKeystoreAuthCtx(ctx, &pco)
 	res, httpr, err := pco.sgkeystoreclient.DefaultApi.GetSecretGroupKeystoreDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get keystore " + id,

--- a/anypoint/data_source_secretgroup_keystores.go
+++ b/anypoint/data_source_secretgroup_keystores.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -112,14 +111,7 @@ func dataSourceSecretGroupKeystoresRead(ctx context.Context, d *schema.ResourceD
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get keystores for secret-group " + sgid,

--- a/anypoint/data_source_secretgroup_tlscontext_flexgateway.go
+++ b/anypoint/data_source_secretgroup_tlscontext_flexgateway.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -137,14 +136,7 @@ func dataSourceSecretGroupTlsContextFGRead(ctx context.Context, d *schema.Resour
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get tls-context " + id,

--- a/anypoint/data_source_secretgroup_tlscontext_mule.go
+++ b/anypoint/data_source_secretgroup_tlscontext_mule.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -120,14 +119,7 @@ func dataSourceSecretGroupTlsContextMuleRead(ctx context.Context, d *schema.Reso
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get tls-context " + id,

--- a/anypoint/data_source_secretgroup_tlscontext_securityfabric.go
+++ b/anypoint/data_source_secretgroup_tlscontext_securityfabric.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -376,14 +375,7 @@ func dataSourceSecretGroupTlsContextSFRead(ctx context.Context, d *schema.Resour
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContextDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get tls-context " + id,

--- a/anypoint/data_source_secretgroup_tlscontexts.go
+++ b/anypoint/data_source_secretgroup_tlscontexts.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -82,14 +81,7 @@ func dataSourceSecretGroupTlsContextsRead(ctx context.Context, d *schema.Resourc
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.GetSecretGroupTlsContexts(authctx, orgid, envid, sgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get tls-contexts for secret-group " + sgid,

--- a/anypoint/data_source_secretgroup_truststore.go
+++ b/anypoint/data_source_secretgroup_truststore.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -104,14 +103,7 @@ func dataSourceSecretGroupTruststoreRead(ctx context.Context, d *schema.Resource
 	authctx := getSgTruststoreAuthCtx(ctx, &pco)
 	res, httpr, err := pco.sgtruststoreclient.DefaultApi.GetSecretGroupTruststoreDetails(authctx, orgid, envid, sgid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get truststore " + id,

--- a/anypoint/data_source_secretgroup_truststores.go
+++ b/anypoint/data_source_secretgroup_truststores.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -112,14 +111,7 @@ func dataSourceSecretGroupTruststoresRead(ctx context.Context, d *schema.Resourc
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get truststores for secret-group " + sgid,

--- a/anypoint/data_source_secretgroups.go
+++ b/anypoint/data_source_secretgroups.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"maps"
 	"strconv"
 	"time"
@@ -126,14 +125,7 @@ func dataSourceSecretGroupsRead(ctx context.Context, d *schema.ResourceData, m a
 	//execut request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get secret groups for org " + orgid + " and env " + envid,

--- a/anypoint/data_source_team.go
+++ b/anypoint/data_source_team.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -82,14 +81,7 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m any) diag
 	//request roles
 	res, httpr, err := pco.teamclient.DefaultAPI.GetTeam(authctx, orgid, teamid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid,

--- a/anypoint/data_source_team_groupmappings.go
+++ b/anypoint/data_source_team_groupmappings.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -99,14 +98,7 @@ func dataSourceTeamGroupMappingsRead(ctx context.Context, d *schema.ResourceData
 	//request members
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid + " groupmappings ",

--- a/anypoint/data_source_team_members.go
+++ b/anypoint/data_source_team_members.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -152,14 +151,7 @@ func dataSourceTeamMembersRead(ctx context.Context, d *schema.ResourceData, m an
 	//perform request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid + " member ",

--- a/anypoint/data_source_team_role.go
+++ b/anypoint/data_source_team_role.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -66,14 +65,7 @@ func dataSourceTeamRoleRead(ctx context.Context, d *schema.ResourceData, m any) 
 	authctx := getTeamRolesAuthCtx(ctx, &pco)
 	res, httpr, err := pco.teamrolesclient.DefaultAPI.GetTeamRoles(authctx, orgid, teamid).RoleId(roleid).Limit(500).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read team role " + roleid + " for team " + teamid,

--- a/anypoint/data_source_team_roles.go
+++ b/anypoint/data_source_team_roles.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -115,14 +114,7 @@ func dataSourceTeamRolesRead(ctx context.Context, d *schema.ResourceData, m any)
 	//request roles
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid + " roles ",

--- a/anypoint/data_source_teams.go
+++ b/anypoint/data_source_teams.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -170,14 +169,7 @@ func dataSourceTeamsRead(ctx context.Context, d *schema.ResourceData, m any) dia
 	//request roles
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get teams",

--- a/anypoint/data_source_user.go
+++ b/anypoint/data_source_user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -154,14 +153,7 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, m any) diag
 	//request roles
 	res, httpr, err := pco.userclient.DefaultApi.OrganizationsOrgIdUsersUserIdGet(authctx, orgid, userid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get user " + userid,

--- a/anypoint/data_source_user_rolegroup.go
+++ b/anypoint/data_source_user_rolegroup.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -139,14 +138,7 @@ func searchUserRolegroup(ctx context.Context, d *schema.ResourceData, m any) (*u
 		req = req.Offset(int32(offset))
 		res, httpr, err := req.Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to get user " + userid + " rolegroup " + rolegroupid,

--- a/anypoint/data_source_user_rolegroups.go
+++ b/anypoint/data_source_user_rolegroups.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -145,14 +144,7 @@ func dataSourceUserRolegroupsRead(ctx context.Context, d *schema.ResourceData, m
 	//request roles
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get user rolegroups",

--- a/anypoint/data_source_users.go
+++ b/anypoint/data_source_users.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -189,14 +188,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, m any) dia
 	//perform request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get users",

--- a/anypoint/data_source_vpc.go
+++ b/anypoint/data_source_vpc.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -143,14 +142,7 @@ func dataSourceVPCRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request vpcs
 	res, httpr, err := pco.vpcclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdGet(authctx, orgid, vpcid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get VPC " + vpcid,

--- a/anypoint/data_source_vpcs.go
+++ b/anypoint/data_source_vpcs.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"strconv"
 	"time"
 
@@ -150,14 +149,7 @@ func dataSourceVPCsRead(ctx context.Context, d *schema.ResourceData, m any) diag
 	//request vpcs
 	res, httpr, err := pco.vpcclient.DefaultApi.OrganizationsOrgIdVpcsGet(authctx, orgid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get VPCs",

--- a/anypoint/data_source_vpn.go
+++ b/anypoint/data_source_vpn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -173,14 +172,7 @@ func dataSourceVPNRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request specific VPN
 	res, httpr, err := pco.vpnclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdIpsecVpnIdGet(authctx, orgid, vpcid, vpnid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get VPN " + vpnid,

--- a/anypoint/resource_ame.go
+++ b/anypoint/resource_ame.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -96,14 +95,7 @@ func resourceAMECreate(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request user creation
 	_, httpr, err := pco.ameclient.DefaultApi.CreateAME(authctx, orgid, envid, regionid, exchangeid).ExchangeBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create AME " + exchangeid,
@@ -140,14 +132,7 @@ func resourceAMERead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get AME " + d.Id(),
@@ -191,14 +176,7 @@ func resourceAMEUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.
 		//request resource creation
 		_, httpr, err := pco.ameclient.DefaultApi.UpdateAME(authctx, orgid, envid, regionid, exchangeid).ExchangeBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to patch AME " + d.Id(),
@@ -224,14 +202,7 @@ func resourceAMEDelete(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	httpr, err := pco.ameclient.DefaultApi.DeleteAME(authctx, orgid, envid, regionid, exchangeid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete AME " + d.Id(),

--- a/anypoint/resource_ame_binding.go
+++ b/anypoint/resource_ame_binding.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -303,13 +302,7 @@ func resourceAMEBindingCreate(ctx context.Context, d *schema.ResourceData, m any
 	//request resource creation
 	_, httpr, err := pco.amebindingclient.DefaultApi.CreateAMEBinding(authctx, orgid, envid, regionid, exchangeid, queueid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create AME Binding " + exchangeid + " " + queueid,
@@ -354,14 +347,7 @@ func resourceAMEBindingRead(ctx context.Context, d *schema.ResourceData, m any) 
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get AME Binding " + id,
@@ -417,14 +403,7 @@ func resourceAMEBindingDelete(ctx context.Context, d *schema.ResourceData, m any
 	//perform request
 	httpr, err := pco.amebindingclient.DefaultApi.DeleteAMEBinding(authctx, orgid, envid, regionid, exchangeid, queueid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete AME Binding " + d.Id(),
@@ -473,14 +452,7 @@ func resourceAMEBindingRulesCreate(ctx context.Context, d *schema.ResourceData, 
 	//request resource creation
 	_, httpr, err := pco.amebindingclient.DefaultApi.CreateAMEBindingRule(authctx, orgid, envid, regionid, exchangeid, queueid).AMEBindingRuleBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create AME Binding (" + exchangeid + ", " + queueid + ") Rules",
@@ -506,14 +478,7 @@ func resourceAMEBindingRulesDelete(ctx context.Context, d *schema.ResourceData, 
 	//request resource creation
 	httpr, err := pco.amebindingclient.DefaultApi.DeleteAMEBindingRule(authctx, orgid, envid, regionid, exchangeid, queueid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete AME Binding Rule " + d.Id(),

--- a/anypoint/resource_amq.go
+++ b/anypoint/resource_amq.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -130,14 +129,7 @@ func resourceAMQCreate(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request resource creation
 	_, httpr, err := pco.amqclient.DefaultApi.CreateAMQ(authctx, orgid, envid, regionid, queueid).QueueBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create AMQ ",
@@ -174,14 +166,7 @@ func resourceAMQRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get AMQ " + id,
@@ -226,14 +211,7 @@ func resourceAMQUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.
 		//request user creation
 		_, httpr, err := pco.amqclient.DefaultApi.UpdateAMQ(authctx, orgid, envid, regionid, queueid).QueueBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to patch AMQ " + d.Id(),
@@ -261,14 +239,7 @@ func resourceAMQDelete(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	httpr, err := pco.amqclient.DefaultApi.DeleteAMQ(authctx, orgid, envid, regionid, queueid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete AMQ " + d.Id(),

--- a/anypoint/resource_api_instance_sla_tier.go
+++ b/anypoint/resource_api_instance_sla_tier.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 	"time"
 
@@ -156,14 +155,7 @@ func resourceApiInstanceSlaTierCreate(ctx context.Context, d *schema.ResourceDat
 
 	res, httpr, err := pco.apimtierclient.DefaultAPI.CreateApiInstanceTier(authctx, orgid, envid, apiid).SlaTierPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create SLA tier for api " + apiid,
@@ -257,14 +249,7 @@ func resourceApiInstanceSlaTierUpdate(ctx context.Context, d *schema.ResourceDat
 
 	res, httpr, err := pco.apimtierclient.DefaultAPI.UpdateApiInstanceTier(authctx, orgid, envid, apiid, int32(tierId)).SlaTierPutBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to update SLA tier " + tierIdStr,
@@ -313,14 +298,7 @@ func resourceApiInstanceSlaTierDelete(ctx context.Context, d *schema.ResourceDat
 			d.SetId("")
 			return diags
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete SLA tier " + tierIdStr,
@@ -347,14 +325,7 @@ func apimTierReadById(
 		res, httpr, err := pco.apimtierclient.DefaultAPI.GetApiInstanceTiers(authctx, orgid, envid, apiid).
 			Limit(limit).Offset(offset).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			return nil, diag.Diagnostics{{
 				Severity: diag.Error,
 				Summary:  "Unable to read SLA tiers for api " + apiid,

--- a/anypoint/resource_apim_flexgateway.go
+++ b/anypoint/resource_apim_flexgateway.go
@@ -499,14 +499,7 @@ func resourceApimFlexGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 	// execute post request
 	res, httpr, err := pco.apimclient.DefaultApi.PostApimInstance(authctx, orgid, envid).ApimInstancePostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create API flex gateway for org " + orgid + " and env " + envid,
@@ -546,14 +539,7 @@ func resourceApimFlexGatewayUpstreamsCreate(ctx context.Context, d *schema.Resou
 			//execute post upstream
 			_, httpr, err := pco.apimupstreamclient.DefaultApi.PostApimInstanceUpstream(authctx, orgid, envid, id).UpstreamPostBody(*body).Execute()
 			if err != nil {
-				var details error
-				if httpr != nil && httpr.StatusCode >= 400 {
-					defer httpr.Body.Close()
-					b, _ := io.ReadAll(httpr.Body)
-					details = errors.New(string(b))
-				} else {
-					details = err
-				}
+				details := errors.New(extractAPIErrorDetail(err, httpr))
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Unable to create Flex Gateway upstream " + body.GetLabel() + " for instance " + id,
@@ -589,14 +575,7 @@ func resourceApimFlexGatewayRead(ctx context.Context, d *schema.ResourceData, m 
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get API manager's flex gateway instance",
@@ -642,14 +621,7 @@ func resourceApimFlexGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 			id := item["id"].(string)
 			_, httpr, err := pco.apimupstreamclient.DefaultApi.PatchApimInstanceUpstream(authctx, orgid, envid, apimid, id).UpstreamPatchBody(*body).Execute()
 			if err != nil {
-				var details error
-				if httpr != nil && httpr.StatusCode >= 400 {
-					defer httpr.Body.Close()
-					b, _ := io.ReadAll(httpr.Body)
-					details = errors.New(string(b))
-				} else {
-					details = err
-				}
+				details := errors.New(extractAPIErrorDetail(err, httpr))
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Unable to update Flex Gateway upstream " + id + " for instance " + apimid,
@@ -665,14 +637,7 @@ func resourceApimFlexGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 		for _, body := range bodies {
 			_, httpr, err := pco.apimupstreamclient.DefaultApi.PostApimInstanceUpstream(authctx, orgid, envid, apimid).UpstreamPostBody(*body).Execute()
 			if err != nil {
-				var details error
-				if httpr != nil && httpr.StatusCode >= 400 {
-					defer httpr.Body.Close()
-					b, _ := io.ReadAll(httpr.Body)
-					details = errors.New(string(b))
-				} else {
-					details = err
-				}
+				details := errors.New(extractAPIErrorDetail(err, httpr))
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Unable to create Flex Gateway upstream " + body.GetLabel() + " for instance " + apimid,
@@ -687,14 +652,7 @@ func resourceApimFlexGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 		authctx := getApimAuthCtx(ctx, &pco)
 		_, httpr, err := pco.apimclient.DefaultApi.PatchApimInstance(authctx, orgid, envid, apimid).Body(body).Execute()
 		if err != nil {
-			var details error
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = errors.New(string(b))
-			} else {
-				details = err
-			}
+			details := errors.New(extractAPIErrorDetail(err, httpr))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update Flex Gateway instance " + apimid,
@@ -710,14 +668,7 @@ func resourceApimFlexGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 			id := item["id"].(string)
 			httpr, err := pco.apimupstreamclient.DefaultApi.DeleteApimInstanceUpstream(authctx, orgid, envid, apimid, id).Execute()
 			if err != nil {
-				var details error
-				if httpr != nil && httpr.StatusCode >= 400 {
-					defer httpr.Body.Close()
-					b, _ := io.ReadAll(httpr.Body)
-					details = errors.New(string(b))
-				} else {
-					details = err
-				}
+				details := errors.New(extractAPIErrorDetail(err, httpr))
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Unable to remove Flex Gateway upstream " + id + " for instance " + apimid,
@@ -745,13 +696,7 @@ func resourceApimFlexGatewayRoutingUpdate(ctx context.Context, d *schema.Resourc
 		// patch
 		_, httpr, err := pco.apimclient.DefaultApi.PatchApimInstance(authctx, orgid, envid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "unable to update api manager's flex gateway instance " + id + " with routing parameters ",

--- a/anypoint/resource_apim_mule4.go
+++ b/anypoint/resource_apim_mule4.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"strconv"
 	"strings"
@@ -208,14 +207,7 @@ func resourceApimMule4Create(ctx context.Context, d *schema.ResourceData, m any)
 	// execute post request
 	res, httpr, err := pco.apimclient.DefaultApi.PostApimInstance(authctx, orgid, envid).ApimInstancePostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create api manager mule4 for org " + orgid + " and env " + envid,
@@ -254,14 +246,7 @@ func resourceApimMule4Read(ctx context.Context, d *schema.ResourceData, m any) d
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get API manager's mule4 instance " + id,
@@ -300,14 +285,7 @@ func resourceApimMule4Update(ctx context.Context, d *schema.ResourceData, m any)
 		authctx := getApimAuthCtx(ctx, &pco)
 		_, httpr, err := pco.apimclient.DefaultApi.PatchApimInstance(authctx, orgid, envid, apimid).Body(body).Execute()
 		if err != nil {
-			var details error
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = errors.New(string(b))
-			} else {
-				details = err
-			}
+			details := errors.New(extractAPIErrorDetail(err, httpr))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update api manager instance " + apimid,
@@ -332,14 +310,7 @@ func resourceApimMule4Delete(ctx context.Context, d *schema.ResourceData, m any)
 	//perform request
 	httpr, err := pco.apimclient.DefaultApi.DeleteApimInstance(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete API Manager's Mule4 Instance",

--- a/anypoint/resource_apim_policy_basic_auth.go
+++ b/anypoint/resource_apim_policy_basic_auth.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -167,14 +166,7 @@ func resourceApimInstancePolicyBasicAuthCreate(ctx context.Context, d *schema.Re
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.PostApimPolicy(authctx, orgid, envid, apimid).ApimPolicyBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create policy basic authentication for api " + apimid,
@@ -217,14 +209,7 @@ func resourceApimInstancePolicyBasicAuthRead(ctx context.Context, d *schema.Reso
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read policy basic authentication " + id + " for api " + apimid,
@@ -265,14 +250,7 @@ func resourceApimInstancePolicyBasicAuthUpdate(ctx context.Context, d *schema.Re
 		//perform request
 		_, httpr, err := pco.apimpolicyclient.DefaultApi.PatchApimPolicy(authctx, orgid, envid, apimid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update policy basic authentication for api " + apimid,
@@ -306,14 +284,7 @@ func resourceApimInstancePolicyBasicAuthDelete(ctx context.Context, d *schema.Re
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	httpr, err := pco.apimpolicyclient.DefaultApi.DeleteApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete policy basic authentication " + id + " for api " + apimid,
@@ -338,14 +309,7 @@ func enableApimInstancePolicyBasicAuth(ctx context.Context, d *schema.ResourceDa
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.EnableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to enable policy basic authentication " + id + " for api " + apimid,
@@ -367,14 +331,7 @@ func disableApimInstancePolicyBasicAuth(ctx context.Context, d *schema.ResourceD
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.DisableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to disable policy basic authentication " + id + " for api " + apimid,

--- a/anypoint/resource_apim_policy_client_id_enforcement.go
+++ b/anypoint/resource_apim_policy_client_id_enforcement.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -187,14 +186,7 @@ func resourceApimInstancePolicyClientIdEnfCreate(ctx context.Context, d *schema.
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.PostApimPolicy(authctx, orgid, envid, apimid).ApimPolicyBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create policy client-id-enforcement for api " + apimid,
@@ -237,14 +229,7 @@ func resourceApimInstancePolicyClientIdEnfRead(ctx context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read policy client-id-enforcement " + id + " for api " + apimid,
@@ -285,14 +270,7 @@ func resourceApimInstancePolicyClientIdEnfUpdate(ctx context.Context, d *schema.
 		//perform request
 		_, httpr, err := pco.apimpolicyclient.DefaultApi.PatchApimPolicy(authctx, orgid, envid, apimid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update policy client-id-enforcement for api " + apimid,
@@ -326,14 +304,7 @@ func resourceApimInstancePolicyClientIdEnfDelete(ctx context.Context, d *schema.
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	httpr, err := pco.apimpolicyclient.DefaultApi.DeleteApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete policy client-id-enforcement " + id + " for api " + apimid,
@@ -358,14 +329,7 @@ func enableApimInstancePolicyClientIdEnf(ctx context.Context, d *schema.Resource
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.EnableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to enable policy client-id-enforcement " + id + " for api " + apimid,
@@ -387,14 +351,7 @@ func disableApimInstancePolicyClientIdEnf(ctx context.Context, d *schema.Resourc
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.DisableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to disable policy client-id-enforcement " + id + " for api " + apimid,

--- a/anypoint/resource_apim_policy_custom.go
+++ b/anypoint/resource_apim_policy_custom.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"maps"
 	"strconv"
 
@@ -158,14 +157,7 @@ func resourceApimInstancePolicyCustomCreate(ctx context.Context, d *schema.Resou
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.PostApimPolicy(authctx, orgid, envid, apimid).ApimPolicyBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create custom policy for api " + apimid,
@@ -208,14 +200,7 @@ func resourceApimInstancePolicyCustomRead(ctx context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read custom policy " + id + " for api " + apimid,
@@ -274,14 +259,7 @@ func resourceApimInstancePolicyCustomUpdate(ctx context.Context, d *schema.Resou
 		//perform request
 		_, httpr, err := pco.apimpolicyclient.DefaultApi.PatchApimPolicy(authctx, orgid, envid, apimid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update custom policy for api " + apimid,
@@ -315,14 +293,7 @@ func resourceApimInstancePolicyCustomDelete(ctx context.Context, d *schema.Resou
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	httpr, err := pco.apimpolicyclient.DefaultApi.DeleteApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete custom policy " + id + " for api " + apimid,
@@ -347,14 +318,7 @@ func enableApimInstancePolicyCustom(ctx context.Context, d *schema.ResourceData,
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.EnableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to enable custom policy " + id + " for api " + apimid,
@@ -376,14 +340,7 @@ func disableApimInstancePolicyCustom(ctx context.Context, d *schema.ResourceData
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.DisableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to disable custom policy " + id + " for api " + apimid,

--- a/anypoint/resource_apim_policy_jwt_validation.go
+++ b/anypoint/resource_apim_policy_jwt_validation.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"regexp"
 	"strconv"
@@ -402,14 +401,7 @@ func resourceApimInstancePolicyJwtValidationCreate(ctx context.Context, d *schem
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.PostApimPolicy(authctx, orgid, envid, apimid).ApimPolicyBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create policy jwt-validation for api " + apimid,
@@ -452,14 +444,7 @@ func resourceApimInstancePolicyJwtValidationRead(ctx context.Context, d *schema.
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read policy jwt-validation " + id + " for api " + apimid,
@@ -501,14 +486,7 @@ func resourceApimInstancePolicyJwtValidationUpdate(ctx context.Context, d *schem
 		//perform request
 		_, httpr, err := pco.apimpolicyclient.DefaultApi.PatchApimPolicy(authctx, orgid, envid, apimid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update policy jwt-validation for api " + apimid,
@@ -542,14 +520,7 @@ func resourceApimInstancePolicyJwtValidationDelete(ctx context.Context, d *schem
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	httpr, err := pco.apimpolicyclient.DefaultApi.DeleteApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete policy jwt-validation " + id + " for api " + apimid,
@@ -574,14 +545,7 @@ func enableApimInstancePolicyJwtValidation(ctx context.Context, d *schema.Resour
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.EnableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to enable policy jwt-validation " + id + " for api " + apimid,
@@ -603,14 +567,7 @@ func disableApimInstancePolicyJwtValidation(ctx context.Context, d *schema.Resou
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.DisableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to disable policy jwt-validation " + id + " for api " + apimid,

--- a/anypoint/resource_apim_policy_message_logging.go
+++ b/anypoint/resource_apim_policy_message_logging.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"regexp"
 	"strconv"
 
@@ -221,14 +220,7 @@ func resourceApimInstancePolicyMessageLoggingCreate(ctx context.Context, d *sche
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.PostApimPolicy(authctx, orgid, envid, apimid).ApimPolicyBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create policy message logging for api " + apimid,
@@ -271,14 +263,7 @@ func resourceApimInstancePolicyMessageLoggingRead(ctx context.Context, d *schema
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read policy message logging " + id + " for api " + apimid,
@@ -320,14 +305,7 @@ func resourceApimInstancePolicyMessageLoggingUpdate(ctx context.Context, d *sche
 		//perform request
 		_, httpr, err := pco.apimpolicyclient.DefaultApi.PatchApimPolicy(authctx, orgid, envid, apimid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update policy message logging for api " + apimid,
@@ -361,14 +339,7 @@ func resourceApimInstancePolicyMessageLoggingDelete(ctx context.Context, d *sche
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	httpr, err := pco.apimpolicyclient.DefaultApi.DeleteApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete policy message logging " + id + " for api " + apimid,
@@ -393,14 +364,7 @@ func enableApimInstancePolicyMessageLogging(ctx context.Context, d *schema.Resou
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.EnableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to enable policy message logging " + id + " for api " + apimid,
@@ -422,14 +386,7 @@ func disableApimInstancePolicyMessageLogging(ctx context.Context, d *schema.Reso
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.DisableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to disable policy message logging " + id + " for api " + apimid,

--- a/anypoint/resource_apim_policy_rate_limit.go
+++ b/anypoint/resource_apim_policy_rate_limit.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"regexp"
 	"strconv"
@@ -207,14 +206,7 @@ func resourceApimInstancePolicyRateLimitingCreate(ctx context.Context, d *schema
 	//perform request
 	res, httpr, err := pco.apimpolicyclient.DefaultApi.PostApimPolicy(authctx, orgid, envid, apimid).ApimPolicyBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create policy rate limiting for api " + apimid,
@@ -257,14 +249,7 @@ func resourceApimInstancePolicyRateLimitingRead(ctx context.Context, d *schema.R
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read policy rate limiting " + id + " for api " + apimid,
@@ -306,14 +291,7 @@ func resourceApimInstancePolicyRateLimitingUpdate(ctx context.Context, d *schema
 		//perform request
 		_, httpr, err := pco.apimpolicyclient.DefaultApi.PatchApimPolicy(authctx, orgid, envid, apimid, id).Body(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update policy rate limiting for api " + apimid,
@@ -347,14 +325,7 @@ func resourceApimInstancePolicyRateLimitingDelete(ctx context.Context, d *schema
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	httpr, err := pco.apimpolicyclient.DefaultApi.DeleteApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete policy rate limiting " + id + " for api " + apimid,
@@ -379,14 +350,7 @@ func enableApimInstancePolicyRateLimiting(ctx context.Context, d *schema.Resourc
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.EnableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to enable policy rate limiting " + id + " for api " + apimid,
@@ -408,14 +372,7 @@ func disableApimInstancePolicyRateLimiting(ctx context.Context, d *schema.Resour
 	authctx := getApimPolicyAuthCtx(ctx, &pco)
 	_, httpr, err := pco.apimpolicyclient.DefaultApi.DisableApimPolicy(authctx, orgid, envid, apimid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to disable policy rate limiting " + id + " for api " + apimid,

--- a/anypoint/resource_bg.go
+++ b/anypoint/resource_bg.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"time"
 
@@ -674,14 +673,7 @@ func resourceBGRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read business group " + orgid,

--- a/anypoint/resource_cloudhub2_shared_space_deployment.go
+++ b/anypoint/resource_cloudhub2_shared_space_deployment.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -538,14 +537,7 @@ func resourceCloudhub2SharedSpaceDeploymentCreate(ctx context.Context, d *schema
 	//Execute post deployment
 	res, httpr, err := pco.appmanagerclient.DefaultApi.PostDeployment(authctx, orgid, envid).DeploymentRequestBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create " + name + " deployment for cloudhub 2.0 shared-space.",
@@ -578,14 +570,7 @@ func resourceCloudhub2SharedSpaceDeploymentRead(ctx context.Context, d *schema.R
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read cloudhub2 deployment " + id + " on shared-space.",
@@ -627,14 +612,7 @@ func resourceCloudhub2SharedSpaceDeploymentUpdate(ctx context.Context, d *schema
 	body := newCloudhub2SharedSpaceDeploymentBody(d)
 	_, httpr, err := pco.appmanagerclient.DefaultApi.PatchDeployment(authctx, orgid, envid, id).DeploymentRequestBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to update deployment " + name + " on cloudhub 2.0 shared-space.",
@@ -656,14 +634,7 @@ func resourceCloudhub2SharedSpaceDeploymentDelete(ctx context.Context, d *schema
 	authctx := getAppDeploymentV2AuthCtx(ctx, &pco)
 	httpr, err := pco.appmanagerclient.DefaultApi.DeleteDeployment(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete deployment " + name + " on cloudhub 2.0 shared-space.",

--- a/anypoint/resource_connected_app.go
+++ b/anypoint/resource_connected_app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -186,14 +185,7 @@ func resourceConnectedAppCreate(ctx context.Context, d *schema.ResourceData, m a
 	//request connected app creation
 	res, httpr, err := pco.connectedappclient.DefaultApi.CreateConnectedApp(authctx, orgid).ConnectedAppCore(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create connected-app",
@@ -250,14 +242,7 @@ func resourceConnectedAppRead(ctx context.Context, d *schema.ResourceData, m any
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read connected-app " + connappid,
@@ -308,14 +293,7 @@ func resourceConnectedAppUpdate(ctx context.Context, d *schema.ResourceData, m a
 		//perform request
 		_, httpr, err := pco.connectedappclient.DefaultApi.UpdateConnectedApp(authctx, orgid, connappid).ConnectedAppPatchExt(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update connected-app " + connappid,
@@ -351,14 +329,7 @@ func resourceConnectedAppDelete(ctx context.Context, d *schema.ResourceData, m a
 	// perform request
 	httpr, err := pco.connectedappclient.DefaultApi.DeleteConnectedApp(authctx, orgid, connappid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete connected-app " + connappid,
@@ -383,13 +354,7 @@ func replaceConnectedAppScopes(ctx context.Context, d *schema.ResourceData, m an
 	//request scopes replacement
 	httpr, err := pco.connectedappclient.DefaultApi.UpdateConnectedAppScopes(authctx, orgid, connappid).ConnectedAppScopesPutBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		return errors.New(details)
 	}
 	defer httpr.Body.Close()

--- a/anypoint/resource_dlb.go
+++ b/anypoint/resource_dlb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"strings"
 	"time"
@@ -370,14 +369,7 @@ func resourceDLBCreate(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request user creation
 	res, httpr, err := pco.dlbclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdLoadbalancersPost(authctx, orgid, vpcid).DlbPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create DLB of org " + orgid + " and vpc " + vpcid,
@@ -412,14 +404,7 @@ func resourceDLBRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get dlb " + dlbid,
@@ -458,14 +443,7 @@ func resourceDLBUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.
 		//request user creation
 		_, httpr, err := pco.dlbclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdLoadbalancersDlbIdPatch(authctx, orgid, vpcid, dlbid).RequestBody(body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to patch dlb " + dlbid,
@@ -491,14 +469,7 @@ func resourceDLBDelete(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	httpr, err := pco.dlbclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdLoadbalancersDlbIdDelete(authctx, orgid, vpcid, dlbid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete dlb " + dlbid,

--- a/anypoint/resource_env.go
+++ b/anypoint/resource_env.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -78,14 +77,7 @@ func resourceENVCreate(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request env creation
 	res, httpr, err := pco.envclient.DefaultApi.OrganizationsOrgIdEnvironmentsPost(authctx, orgid).EnvCore(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Create ENV",
@@ -117,14 +109,7 @@ func resourceENVRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read environment " + envid,
@@ -161,14 +146,7 @@ func resourceENVUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.
 		//request env creation
 		_, httpr, err := pco.envclient.DefaultApi.OrganizationsOrgIdEnvironmentsEnvironmentIdPut(authctx, orgid, envid).EnvCore(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update environment " + envid,
@@ -192,14 +170,7 @@ func resourceENVDelete(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	httpr, err := pco.envclient.DefaultApi.OrganizationsOrgIdEnvironmentsEnvironmentIdDelete(authctx, orgid, envid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete environment " + envid,

--- a/anypoint/resource_exchange_asset.go
+++ b/anypoint/resource_exchange_asset.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"time"
@@ -21,7 +20,7 @@ func resourceExchangeAsset() *schema.Resource {
 		ReadContext:   resourceExchangeAssetRead,
 		UpdateContext: resourceExchangeAssetUpdate,
 		DeleteContext: resourceExchangeAssetDelete,
-		Description: "Creates and manages an Exchange asset. Asset metadata is updatable (name, description); all other attributes force replacement.",
+		Description:   "Creates and manages an Exchange asset. Asset metadata is updatable (name, description); all other attributes force replacement.",
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -461,14 +460,7 @@ func splitExchangeAssetId(id string) (orgId, groupId, assetId, version string, e
 }
 
 func exchangeAssetHTTPDiag(httpr *http.Response, err error, summary string) diag.Diagnostics {
-	var details string
-	if httpr != nil && httpr.StatusCode >= 400 {
-		defer httpr.Body.Close()
-		b, _ := io.ReadAll(httpr.Body)
-		details = string(b)
-	} else {
-		details = err.Error()
-	}
+	details := extractAPIErrorDetail(err, httpr)
 	return diag.Diagnostics{{Severity: diag.Error, Summary: summary, Detail: details}}
 }
 

--- a/anypoint/resource_fabrics.go
+++ b/anypoint/resource_fabrics.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -184,14 +183,7 @@ func resourceFabricsCreate(ctx context.Context, d *schema.ResourceData, m any) d
 	//prepare request
 	res, httpr, err := pco.rtfclient.DefaultApi.PostFabrics(authctx, orgid).FabricsPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create fabrics " + name,
@@ -225,14 +217,7 @@ func resourceFabricsRead(ctx context.Context, d *schema.ResourceData, m any) dia
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read fabrics " + fabricsid,
@@ -270,14 +255,7 @@ func resourceFabricsDelete(ctx context.Context, d *schema.ResourceData, m any) d
 	//perform request
 	httpr, err := pco.rtfclient.DefaultApi.DeleteFabrics(authctx, orgid, fabricsid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete fabrics " + fabricsid,

--- a/anypoint/resource_fabrics_associations.go
+++ b/anypoint/resource_fabrics_associations.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -91,14 +90,7 @@ func resourceFabricsAssociationsCreate(ctx context.Context, d *schema.ResourceDa
 	//prepare request
 	_, httpr, err := pco.rtfclient.DefaultApi.PostFabricsAssociations(authctx, orgid, fabricsid).FabricsAssociationsPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create fabrics " + fabricsid + " associations ",
@@ -132,14 +124,7 @@ func resourceFabricsAssociationsRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read fabrics " + fabricsid + " associations",
@@ -175,14 +160,7 @@ func resourceFabricsAssociationsDelete(ctx context.Context, d *schema.ResourceDa
 	//perform request
 	_, httpr, err := pco.rtfclient.DefaultApi.PostFabricsAssociations(authctx, orgid, fabricsid).FabricsAssociationsPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete fabrics " + fabricsid,

--- a/anypoint/resource_idp_oidc.go
+++ b/anypoint/resource_idp_oidc.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -159,14 +158,7 @@ func resourceOIDCCreate(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	res, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersPost(authctx, orgid).IdpPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create OIDC provider for org " + orgid,
@@ -198,14 +190,7 @@ func resourceOIDCRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read OIDC provider " + idpid + " in org " + orgid,
@@ -247,14 +232,7 @@ func resourceOIDCUpdate(ctx context.Context, d *schema.ResourceData, m any) diag
 		//perform request
 		_, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdPatch(authctx, orgid, idpid).IdpPatchBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update OIDC provider " + idpid + " in org " + orgid,
@@ -278,14 +256,7 @@ func resourceOIDCDelete(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdDelete(authctx, orgid, idpid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete OIDC provider " + idpid,

--- a/anypoint/resource_idp_saml.go
+++ b/anypoint/resource_idp_saml.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -165,14 +164,7 @@ func resourceSAMLCreate(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	res, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersPost(authctx, orgid).IdpPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create OIDC provider for org " + orgid,
@@ -204,14 +196,7 @@ func resourceSAMLRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read SAML identity provider " + idpid + " in org " + orgid,
@@ -255,14 +240,7 @@ func resourceSAMLUpdate(ctx context.Context, d *schema.ResourceData, m any) diag
 		//perform request
 		_, httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdPatch(authctx, orgid, idpid).IdpPatchBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to Update IDP " + idpid + " in org " + orgid,
@@ -287,14 +265,7 @@ func resourceSAMLDelete(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	httpr, err := pco.idpclient.DefaultApi.OrganizationsOrgIdIdentityProvidersIdpIdDelete(authctx, orgid, idpid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete OIDC provider " + idpid,

--- a/anypoint/resource_private_space.go
+++ b/anypoint/resource_private_space.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"time"
 
@@ -189,14 +188,7 @@ func resourcePrivateSpaceCreate(ctx context.Context, d *schema.ResourceData, m a
 	//request
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.CreatePrivateSpace(authctx, orgid).PrivateSpacePostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Create Private Space " + res.GetId() + " for org " + orgid,
@@ -233,14 +225,7 @@ func resourcePrivateSpaceRead(ctx context.Context, d *schema.ResourceData, m any
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read Private Space " + id + " for org " + orgid,
@@ -283,14 +268,7 @@ func resourcePrivateSpaceUpdate(ctx context.Context, d *schema.ResourceData, m a
 		//request
 		_, httpr, err := pco.privatespaceclient.DefaultAPI.UpdatePrivateSpace(authctx, orgid, id).PrivateSpacePatchBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to Update Private Space " + id + " for org " + orgid,
@@ -314,14 +292,7 @@ func resourcePrivateSpaceDelete(ctx context.Context, d *schema.ResourceData, m a
 	//request
 	httpr, err := pco.privatespaceclient.DefaultAPI.DeletePrivateSpace(authctx, orgid, d.Id()).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete Private Space for org " + orgid,

--- a/anypoint/resource_private_space_tlscontext_jks.go
+++ b/anypoint/resource_private_space_tlscontext_jks.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -220,14 +219,7 @@ func resourcePrivateSpaceTlsContextJKSCreate(ctx context.Context, d *schema.Reso
 	//request
 	tlscontext, httpr, err := pco.privatespacetlscontextclient.DefaultApi.CreateTlsContext(authctx, orgid, private_space_id).TlsContextPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Create Private Space TLS Context for org " + orgid + " and private space " + private_space_id,
@@ -262,14 +254,7 @@ func resourcePrivateSpaceTlsContextJKSRead(ctx context.Context, d *schema.Resour
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read Private Space TLS Context for org " + orgid + " and private space " + private_space_id,
@@ -307,14 +292,7 @@ func resourcePrivateSpaceTlsContextJKSUpdate(ctx context.Context, d *schema.Reso
 		//request
 		tlscontext, httpr, err := pco.privatespacetlscontextclient.DefaultApi.UpdateTlsContext(authctx, orgid, private_space_id, id).Body(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to Update Private Space TLS Context for org " + orgid + " and private space " + private_space_id,
@@ -341,14 +319,7 @@ func resourcePrivateSpaceTlsContextJKSDelete(ctx context.Context, d *schema.Reso
 	//request
 	httpr, err := pco.privatespacetlscontextclient.DefaultApi.DeleteTlsContext(authctx, orgid, private_space_id, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete Private Space TLS Context for org " + orgid + " and private space " + private_space_id,

--- a/anypoint/resource_private_space_tlscontext_pem.go
+++ b/anypoint/resource_private_space_tlscontext_pem.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -220,14 +219,7 @@ func resourcePrivateSpaceTlsContextPemCreate(ctx context.Context, d *schema.Reso
 	//request
 	tlscontext, httpr, err := pco.privatespacetlscontextclient.DefaultApi.CreateTlsContext(authctx, orgid, private_space_id).TlsContextPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Create Private Space TLS Context for org " + orgid + " and private space " + private_space_id,
@@ -262,14 +254,7 @@ func resourcePrivateSpaceTlsContextPemRead(ctx context.Context, d *schema.Resour
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Get Private Space TLS Context for org " + orgid + " and private space " + private_space_id + " and id " + id,
@@ -308,14 +293,7 @@ func resourcePrivateSpaceTlsContextPemUpdate(ctx context.Context, d *schema.Reso
 		//request
 		_, httpr, err := pco.privatespacetlscontextclient.DefaultApi.UpdateTlsContext(authctx, orgid, private_space_id, id).Body(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to Update Private Space TLS Context for org " + orgid + " and private space " + private_space_id + " and id " + id,
@@ -340,14 +318,7 @@ func resourcePrivateSpaceTlsContextPemDelete(ctx context.Context, d *schema.Reso
 	//request
 	httpr, err := pco.privatespacetlscontextclient.DefaultApi.DeleteTlsContext(authctx, orgid, private_space_id, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete Private Space TLS Context for org " + orgid + " and id " + id,

--- a/anypoint/resource_private_space_transit_gateway.go
+++ b/anypoint/resource_private_space_transit_gateway.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -121,14 +120,7 @@ func resourcePrivateSpaceTransitGatewayCreate(ctx context.Context, d *schema.Res
 	body := newPrivateSpaceTransitGatewayPostBody(d)
 	res, httpr, err := pco.privatespaceclient.DefaultAPI.CreatePrivateSpaceTransitGateway(authctx, orgid, psid).TransitGatewayPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Create transit gateway " + d.Get("name").(string) + " for private space " + psid,
@@ -157,14 +149,7 @@ func resourcePrivateSpaceTransitGatewayRead(ctx context.Context, d *schema.Resou
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Read transit gateway " + tgwid + " for private space " + psid,
@@ -210,14 +195,7 @@ func resourcePrivateSpaceTransitGatewayUpdate(ctx context.Context, d *schema.Res
 		body := private_space.NewTransitGatewayPatchRoutesBody(ListInterface2ListStrings(d.Get("routes").(*schema.Set).List()))
 		_, httpr, err := pco.privatespaceclient.DefaultAPI.UpdatePrivateSpaceTransitGatewayRoutes(authctx, orgid, psid, tgwid).TransitGatewayPatchRoutesBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to Update routes for transit gateway " + tgwid,
@@ -231,14 +209,7 @@ func resourcePrivateSpaceTransitGatewayUpdate(ctx context.Context, d *schema.Res
 		body := private_space.NewTransitGatewayPatchNameBody(d.Get("name").(string))
 		_, httpr, err := pco.privatespaceclient.DefaultAPI.UpdateOrgTransitGatewayName(authctx, orgid, tgwid).TransitGatewayPatchNameBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to Update name for transit gateway " + tgwid,
@@ -262,14 +233,7 @@ func resourcePrivateSpaceTransitGatewayDelete(ctx context.Context, d *schema.Res
 	authctx := getPrivateSpaceAuthCtx(ctx, &pco)
 	httpr, err := pco.privatespaceclient.DefaultAPI.DeletePrivateSpaceTransitGateway(authctx, orgid, psid, tgwid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete transit gateway " + tgwid + " for private space " + psid,

--- a/anypoint/resource_private_space_vpn.go
+++ b/anypoint/resource_private_space_vpn.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -592,14 +591,7 @@ func splitPrivateSpaceVpnId(d *schema.ResourceData) (string, string, string, dia
 }
 
 func diagFromHttp(summary string, httpr *http.Response, err error) diag.Diagnostic {
-	var details string
-	if httpr != nil && httpr.StatusCode >= 400 {
-		defer httpr.Body.Close()
-		b, _ := io.ReadAll(httpr.Body)
-		details = string(b)
-	} else {
-		details = err.Error()
-	}
+	details := extractAPIErrorDetail(err, httpr)
 	return diag.Diagnostic{
 		Severity: diag.Error,
 		Summary:  summary,

--- a/anypoint/resource_rolegroup.go
+++ b/anypoint/resource_rolegroup.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"time"
 
@@ -105,14 +104,7 @@ func resourceRoleGroupCreate(ctx context.Context, d *schema.ResourceData, m any)
 	//perform request
 	res, httpr, err := pco.rolegroupclient.DefaultApi.OrganizationsOrgIdRolegroupsPost(authctx, orgid).RolegroupPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create rolegroup " + name,
@@ -144,14 +136,7 @@ func resourceRoleGroupRead(ctx context.Context, d *schema.ResourceData, m any) d
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get rolegroup " + rolegroupid,
@@ -194,14 +179,7 @@ func resourceRoleGroupUpdate(ctx context.Context, d *schema.ResourceData, m any)
 		//perform request
 		_, httpr, err := pco.rolegroupclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdPut(authctx, orgid, rolegroupid).RolegroupPutBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update rolegroup",
@@ -226,14 +204,7 @@ func resourceRoleGroupDelete(ctx context.Context, d *schema.ResourceData, m any)
 	//perform request
 	_, httpr, err := pco.rolegroupclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdDelete(authctx, orgid, rolegroupid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get rolegroup " + rolegroupid,

--- a/anypoint/resource_rolegroup_roles.go
+++ b/anypoint/resource_rolegroup_roles.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -113,14 +112,7 @@ func resourceRoleGroupRolesCreate(ctx context.Context, d *schema.ResourceData, m
 	//perform request
 	_, httpr, err := pco.roleclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdRolesPost(authctx, org_id, rolegroup_id).RequestBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to assign roles to rolegroup " + rolegroup_id,
@@ -155,14 +147,7 @@ func resourceRoleGroupRolesRead(ctx context.Context, d *schema.ResourceData, m a
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get rolegroup " + rolegroup_id + " assigned roles",
@@ -216,14 +201,7 @@ func resourceRoleGroupRolesDelete(ctx context.Context, d *schema.ResourceData, m
 	//perform request
 	_, httpr, err := pco.roleclient.DefaultApi.OrganizationsOrgIdRolegroupsRolegroupIdRolesDelete(authctx, org_id, rolegroup_id).RequestBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to Delete rolegroup roles",

--- a/anypoint/resource_rtf_deployment.go
+++ b/anypoint/resource_rtf_deployment.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -589,14 +588,7 @@ func resourceRTFDeploymentCreate(ctx context.Context, d *schema.ResourceData, m 
 	//Execute post deployment
 	res, httpr, err := pco.appmanagerclient.DefaultApi.PostDeployment(authctx, orgid, envid).DeploymentRequestBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create " + name + " deployment for runtime fabrics.",
@@ -629,14 +621,7 @@ func resourceRTFDeploymentRead(ctx context.Context, d *schema.ResourceData, m an
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read runtime fabrics deployment " + id + ".",
@@ -678,14 +663,7 @@ func resourceRTFDeploymentUpdate(ctx context.Context, d *schema.ResourceData, m 
 	body := newRTFDeploymentBody(d)
 	_, httpr, err := pco.appmanagerclient.DefaultApi.PatchDeployment(authctx, orgid, envid, id).DeploymentRequestBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to update deployment " + name + " on runtime fabrics.",
@@ -707,14 +685,7 @@ func resourceRTFDeploymentDelete(ctx context.Context, d *schema.ResourceData, m 
 	authctx := getAppDeploymentV2AuthCtx(ctx, &pco)
 	httpr, err := pco.appmanagerclient.DefaultApi.DeleteDeployment(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete deployment " + name + " on cloudhub 2.0 shared-space.",

--- a/anypoint/resource_secretgroup.go
+++ b/anypoint/resource_secretgroup.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -107,14 +106,7 @@ func resourceSecretGroupCreate(ctx context.Context, d *schema.ResourceData, m an
 	// execute post request
 	res, httpr, err := pco.secretgroupclient.DefaultApi.PostSecretGroup(authctx, orgid, envid).SecretGroupPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create secret group for org " + orgid + " and env " + envid,
@@ -149,14 +141,7 @@ func resourceSecretGroupRead(ctx context.Context, d *schema.ResourceData, m any)
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get secret group " + id,
@@ -194,14 +179,7 @@ func resourceSecretGroupUpdate(ctx context.Context, d *schema.ResourceData, m an
 		body := newSecretGroupPatchBody(d)
 		_, httpr, err := pco.secretgroupclient.DefaultApi.PatchSecretGroup(authctx, orgid, envid, id).SecretGroupPatchBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update secret group " + id,
@@ -226,14 +204,7 @@ func resourceSecretGroupDelete(ctx context.Context, d *schema.ResourceData, m an
 	authctx := getSecretGroupAuthCtx(ctx, &pco)
 	httpr, err := pco.secretgroupclient.DefaultApi.DeleteSecretGroup(authctx, orgid, envid, id).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete secret group " + id,

--- a/anypoint/resource_secretgroup_certificate.go
+++ b/anypoint/resource_secretgroup_certificate.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -133,14 +132,7 @@ func resourceSecretGroupCertificateCreate(ctx context.Context, d *schema.Resourc
 	//Execute request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create certificate " + name,
@@ -176,14 +168,7 @@ func resourceSecretGroupCertificateRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get certificate " + id,
@@ -235,14 +220,7 @@ func resourceSecretGroupCertificateUpdate(ctx context.Context, d *schema.Resourc
 		//Execute request
 		_, httpr, err := req.Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update certificate " + id,

--- a/anypoint/resource_secretgroup_crldistrib_cfgs.go
+++ b/anypoint/resource_secretgroup_crldistrib_cfgs.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -118,14 +117,7 @@ func resourceSecretGroupCrlDistribCfgsCreate(ctx context.Context, d *schema.Reso
 	//perform request
 	res, httpr, err := pco.sgcrldistribcfgsclient.DefaultApi.PostSecretGroupCrlDistribCfgs(authctx, orgid, envid, sgid).CrlDistribCfgsReqBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create crl-distributor-configs " + name,
@@ -159,14 +151,7 @@ func resourceSecretGroupCrlDistribCfgsRead(ctx context.Context, d *schema.Resour
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get crl-distributor-configs " + id,
@@ -207,14 +192,7 @@ func resourceSecretGroupCrlDistribCfgsUpdate(ctx context.Context, d *schema.Reso
 		// perform request
 		_, httpr, err := pco.sgcrldistribcfgsclient.DefaultApi.PutSecretGroupTlsContext(authctx, orgid, envid, sgid, id).CrlDistribCfgsReqBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update crl-distributor-configs " + id,

--- a/anypoint/resource_secretgroup_keystore.go
+++ b/anypoint/resource_secretgroup_keystore.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -206,14 +205,7 @@ func resourceSecretGroupKeystoreCreate(ctx context.Context, d *schema.ResourceDa
 	//Execute request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create keystore " + name,
@@ -247,14 +239,7 @@ func resourceSecretGroupKeystoreRead(ctx context.Context, d *schema.ResourceData
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read keystore " + id,
@@ -312,14 +297,7 @@ func resourceSecretGroupKeystoreUpdate(ctx context.Context, d *schema.ResourceDa
 		//Execute request
 		_, httpr, err := req.Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update keystore " + id,

--- a/anypoint/resource_secretgroup_tlscontext_flexgateway.go
+++ b/anypoint/resource_secretgroup_tlscontext_flexgateway.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -206,14 +205,7 @@ func resourceSecretGroupTlsContextFGCreate(ctx context.Context, d *schema.Resour
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.PostSecretGroupTlsContext(authctx, orgid, envid, sgid).TlsContextPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create tls-context " + name,
@@ -249,14 +241,7 @@ func resourceSecretGroupTlsContextFGRead(ctx context.Context, d *schema.Resource
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get tls-context " + id,
@@ -304,14 +289,7 @@ func resourceSecretGroupTlsContextFGUpdate(ctx context.Context, d *schema.Resour
 		// perform request
 		_, httpr, err := pco.sgtlscontextclient.DefaultApi.PutSecretGroupTlsContext(authctx, orgid, envid, sgid, id).TlsContextPutBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update tls-context " + id,

--- a/anypoint/resource_secretgroup_tlscontext_mule.go
+++ b/anypoint/resource_secretgroup_tlscontext_mule.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -170,14 +169,7 @@ func resourceSecretGroupTlsContextMuleCreate(ctx context.Context, d *schema.Reso
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.PostSecretGroupTlsContext(authctx, orgid, envid, sgid).TlsContextPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create tls-context " + name,
@@ -211,14 +203,7 @@ func resourceSecretGroupTlsContextMuleRead(ctx context.Context, d *schema.Resour
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read tls-context " + id,
@@ -266,13 +251,7 @@ func resourceSecretGroupTlsContextMuleUpdate(ctx context.Context, d *schema.Reso
 		// perform request
 		_, httpr, err := pco.sgtlscontextclient.DefaultApi.PutSecretGroupTlsContext(authctx, orgid, envid, sgid, id).TlsContextPutBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update tls-context " + id,

--- a/anypoint/resource_secretgroup_tlscontext_securityfabric.go
+++ b/anypoint/resource_secretgroup_tlscontext_securityfabric.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -450,14 +449,7 @@ func resourceSecretGroupTlsContextSFCreate(ctx context.Context, d *schema.Resour
 	//perform request
 	res, httpr, err := pco.sgtlscontextclient.DefaultApi.PostSecretGroupTlsContext(authctx, orgid, envid, sgid).TlsContextPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create tls-context " + name,
@@ -492,14 +484,7 @@ func resourceSecretGroupTlsContextSFRead(ctx context.Context, d *schema.Resource
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read tls-context " + id,
@@ -548,14 +533,7 @@ func resourceSecretGroupTlsContextSFUpdate(ctx context.Context, d *schema.Resour
 		// perform request
 		_, httpr, err := pco.sgtlscontextclient.DefaultApi.PutSecretGroupTlsContext(authctx, orgid, envid, sgid, id).TlsContextPutBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update tls-context " + id,

--- a/anypoint/resource_secretgroup_truststore.go
+++ b/anypoint/resource_secretgroup_truststore.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -161,14 +160,7 @@ func resourceSecretGroupTruststoreCreate(ctx context.Context, d *schema.Resource
 	//Execute request
 	res, httpr, err := req.Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create truststore " + name,
@@ -204,14 +196,7 @@ func resourceSecretGroupTruststoreRead(ctx context.Context, d *schema.ResourceDa
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read truststore " + id,
@@ -268,14 +253,7 @@ func resourceSecretGroupTruststoreUpdate(ctx context.Context, d *schema.Resource
 		//Execute request
 		_, httpr, err := req.Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update truststore " + id,

--- a/anypoint/resource_team.go
+++ b/anypoint/resource_team.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -101,14 +100,7 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m any) diag
 	//request user creation
 	res, httpr, err := pco.teamclient.DefaultAPI.CreateTeam(authctx, orgid).TeamPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create team ",
@@ -140,14 +132,7 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid,
@@ -186,14 +171,7 @@ func resourceTeamUpdate(ctx context.Context, d *schema.ResourceData, m any) diag
 		//request user creation
 		_, httpr, err := pco.teamclient.DefaultAPI.UpdateTeam(authctx, orgid, teamid).TeamPatchBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to patch team " + teamid,
@@ -210,14 +188,7 @@ func resourceTeamUpdate(ctx context.Context, d *schema.ResourceData, m any) diag
 		//request user creation
 		_, httpr, err := pco.teamclient.DefaultAPI.MoveTeam(authctx, orgid, teamid).TeamPutBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to move team " + teamid,
@@ -241,14 +212,7 @@ func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	httpr, err := pco.teamclient.DefaultAPI.DeleteTeam(authctx, orgid, teamid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete team " + teamid,

--- a/anypoint/resource_team_groupmappings.go
+++ b/anypoint/resource_team_groupmappings.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -100,14 +99,7 @@ func resourceTeamGroupMappingsCreate(ctx context.Context, d *schema.ResourceData
 	//request put
 	httpr, err := pco.teamgroupmappingsclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdGroupmappingsPut(authctx, orgid, teamid).RequestBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create team group mappings for team" + teamid,
@@ -130,14 +122,7 @@ func resourceTeamGroupMappingsUpdate(ctx context.Context, d *schema.ResourceData
 	//perform request
 	httpr, err := pco.teamgroupmappingsclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdGroupmappingsPut(authctx, orgid, teamid).RequestBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to update team group mappings for team " + teamid,
@@ -160,14 +145,7 @@ func resourceTeamGroupMappingsDelete(ctx context.Context, d *schema.ResourceData
 	//perform request
 	httpr, err := pco.teamgroupmappingsclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdGroupmappingsPut(authctx, orgid, teamid).RequestBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete team group mappings for team " + teamid,
@@ -202,14 +180,7 @@ func resourceTeamGroupMappingsRead(ctx context.Context, d *schema.ResourceData, 
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid + " groupmappings",

--- a/anypoint/resource_team_member.go
+++ b/anypoint/resource_team_member.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -101,14 +100,7 @@ func resourceTeamMemberCreate(ctx context.Context, d *schema.ResourceData, m any
 	//request user creation
 	httpr, err := pco.teammembersclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdMembersUserIdPut(authctx, orgid, teamid, userid).TeamMemberPutBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to add team member ",
@@ -147,14 +139,7 @@ func resourceTeamMemberRead(ctx context.Context, d *schema.ResourceData, m any) 
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid + " members",
@@ -201,14 +186,7 @@ func resourceTeamMemberDelete(ctx context.Context, d *schema.ResourceData, m any
 	//perform request
 	httpr, err := pco.teammembersclient.DefaultApi.OrganizationsOrgIdTeamsTeamIdMembersUserIdDelete(authctx, orgid, teamid, userid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete team " + teamid + " member" + userid,

--- a/anypoint/resource_team_role.go
+++ b/anypoint/resource_team_role.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -106,14 +105,7 @@ func resourceTeamRoleCreate(ctx context.Context, d *schema.ResourceData, m any) 
 	body := []team_roles.TeamRolePostBody{newTeamRolePostBody(roleid, ctxOrg, envId)}
 	httpr, err := pco.teamrolesclient.DefaultAPI.AssignTeamRoles(authctx, orgid, teamid).TeamRolePostBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create team role " + roleid + " for team " + teamid,
@@ -143,14 +135,7 @@ func resourceTeamRoleRead(ctx context.Context, d *schema.ResourceData, m any) di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to read team role " + roleid + " for team " + teamid,
@@ -203,14 +188,7 @@ func resourceTeamRoleDelete(ctx context.Context, d *schema.ResourceData, m any) 
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete team role " + roleid + " for team " + teamid,

--- a/anypoint/resource_team_roles.go
+++ b/anypoint/resource_team_roles.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -96,14 +95,7 @@ func resourceTeamRolesCreate(ctx context.Context, d *schema.ResourceData, m any)
 	//request user creation
 	httpr, err := pco.teamrolesclient.DefaultAPI.AssignTeamRoles(authctx, orgid, teamid).TeamRolePostBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create team " + teamid + " roles ",
@@ -139,14 +131,7 @@ func resourceTeamRolesRead(ctx context.Context, d *schema.ResourceData, m any) d
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get team " + teamid + " roles",
@@ -195,14 +180,7 @@ func resourceTeamRolesDelete(ctx context.Context, d *schema.ResourceData, m any)
 	//perform requeset
 	httpr, err := pco.teamrolesclient.DefaultAPI.DeleteTeamRoles(authctx, orgid, teamid).TeamRoleDeleteBody(body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete team " + teamid + " roles",

--- a/anypoint/resource_user.go
+++ b/anypoint/resource_user.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -179,14 +178,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	res, httpr, err := pco.userclient.DefaultApi.OrganizationsOrgIdUsersPost(authctx, orgid).UserPostBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create user " + username,
@@ -218,14 +210,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, m any) diag.D
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to retrieve user " + userid,
@@ -264,14 +249,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m any) diag
 		//request user creation
 		_, httpr, err := pco.userclient.DefaultApi.OrganizationsOrgIdUsersUserIdPut(authctx, orgid, userid).UserPutBody(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update user " + userid,
@@ -296,14 +274,7 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, m any) diag
 	//perform request
 	httpr, err := pco.userclient.DefaultApi.OrganizationsOrgIdUsersUserIdDelete(authctx, orgid, userid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete user " + userid,

--- a/anypoint/resource_user_rolegroup.go
+++ b/anypoint/resource_user_rolegroup.go
@@ -2,7 +2,6 @@ package anypoint
 
 import (
 	"context"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -115,14 +114,7 @@ func resourceUserRolegroupCreate(ctx context.Context, d *schema.ResourceData, m 
 	//request user creation
 	httpr, err := pco.userrgpclient.DefaultApi.OrganizationsOrgIdUsersUserIdRolegroupsRolegroupIdPost(authctx, orgid, userid, rolegroupid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to assign user " + userid + " rolegroup " + rolegroupid,
@@ -189,14 +181,7 @@ func resourceUserRolegroupDelete(ctx context.Context, d *schema.ResourceData, m 
 	//perform request
 	httpr, err := pco.userrgpclient.DefaultApi.OrganizationsOrgIdUsersUserIdRolegroupsRolegroupIdDelete(authctx, orgid, userid, rolegroupid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete user " + userid + " rolegroup " + rolegroupid,

--- a/anypoint/resource_vpc.go
+++ b/anypoint/resource_vpc.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"time"
 
@@ -177,14 +176,7 @@ func resourceVPCCreate(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//request vpc creation
 	res, httpr, err := pco.vpcclient.DefaultApi.OrganizationsOrgIdVpcsPost(authctx, orgid).VpcCore(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create vpc " + name,
@@ -216,14 +208,7 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get vpc " + vpcid,
@@ -262,14 +247,7 @@ func resourceVPCUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.
 		//request vpc creation
 		_, httpr, err := pco.vpcclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdPut(authctx, orgid, vpcid).VpcCore(*body).Execute()
 		if err != nil {
-			var details string
-			if httpr != nil && httpr.StatusCode >= 400 {
-				defer httpr.Body.Close()
-				b, _ := io.ReadAll(httpr.Body)
-				details = string(b)
-			} else {
-				details = err.Error()
-			}
+			details := extractAPIErrorDetail(err, httpr)
 			diags := append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unable to update vpc " + vpcid,
@@ -295,14 +273,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	httpr, err := pco.vpcclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdDelete(authctx, orgid, vpcid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete vpc " + vpcid,

--- a/anypoint/resource_vpn.go
+++ b/anypoint/resource_vpn.go
@@ -3,7 +3,6 @@ package anypoint
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -199,14 +198,7 @@ func resourceVPNCreate(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	res, httpr, err := pco.vpnclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdIpsecPost(authctx, orgid, vpcid).VpnPostReqBody(*body).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to create vpn " + name,
@@ -240,14 +232,7 @@ func resourceVPNRead(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			d.SetId("")
 			return nil
 		}
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to get vpn " + vpnid,
@@ -293,14 +278,7 @@ func resourceVPNDelete(ctx context.Context, d *schema.ResourceData, m any) diag.
 	//perform request
 	httpr, err := pco.vpnclient.DefaultApi.OrganizationsOrgIdVpcsVpcIdIpsecVpnIdDelete(authctx, orgid, vpcid, vpnid).Execute()
 	if err != nil {
-		var details string
-		if httpr != nil && httpr.StatusCode >= 400 {
-			defer httpr.Body.Close()
-			b, _ := io.ReadAll(httpr.Body)
-			details = string(b)
-		} else {
-			details = err.Error()
-		}
+		details := extractAPIErrorDetail(err, httpr)
 		diags := append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Unable to delete vpn " + vpnid,


### PR DESCRIPTION
## Summary

- Every `resource_*.go` and `data_source_*.go` duplicated the same 8-line block to extract error details from an Anypoint API response. Replaces all 256 sites across 118 files with a single call to the shared `extractAPIErrorDetail` helper (added in #125).
- Fixes a latent bug surfaced by #54: the openapi-generator client drains `httpr.Body` inside `Execute()` and caches it on `GenericOpenAPIError`, so the old pattern was reading `httpr.Body` again and getting nothing — every API failure surfaced to the user with `diag.Detail=""`. New helper reads `err.(*GenericOpenAPIError).Body()` first and prefixes the HTTP status code.
- Pre-existing `diagFromHttp` helper in `resource_private_space_vpn.go` now delegates to the shared helper too.

## Related

- Depends on: #125 (introduces the helper in `util.go`)

## Type of change

- [x] Refactor / internal change

## Checklist

### Code

- [x] `gofmt -w anypoint/` and `goimports -w anypoint/` clean.
- [x] `make build` passes.
- [x] `go vet ./...` clean.

### Spec / client dependency

- [x] No spec change. No client module bump.
- [x] `go.mod` has no `replace` directive for `anypoint-client-go/*`.

### Verification

- [x] `make install` against local provider.
- [x] Playground `terraform init -upgrade` + `terraform plan` clean (provider loads, refactored data source `anypoint_bg` reads cleanly, no diff).
- [x] No behavior change in the success path — the only observable user-facing change is that API error diagnostics now include the actual response body and HTTP status code instead of an empty string.

## Notes for reviewer

- Mechanical change. Three pattern variants matched:
  - **Canonical** (`var details string` + `defer httpr.Body.Close()`) — 245 sites.
  - **No-defer variant** (`var details string` without `defer`) — 4 sites in `data_source_connected_app.go`, `resource_ame_binding.go`, `resource_connected_app.go`, `resource_secretgroup_tlscontext_mule.go`.
  - **Error-typed variant** (`var details error` + `errors.New(string(b))`, used where caller calls `details.Error()`) — 7 sites in `resource_apim_flexgateway.go` (×6) and `resource_apim_mule4.go` (×1). Replaced with `errors.New(extractAPIErrorDetail(err, httpr))` to preserve the `error` type at the call site.
- Diff is +257 / -2161 — roughly 2000 lines of duplication gone.
- **Out of scope** (intentionally): retry rollout across resources. Each resource needs idempotency review before wrapping its Create path. PR3 (per-resource retry audit, grouped by service) is queued separately.