### PR TITLE
fix(connected_app): reject reserved "profile" scope at plan time (#26 follow-up)

### DIFF
--- a/anypoint/resource_connected_app.go
+++ b/anypoint/resource_connected_app.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -20,7 +21,6 @@ func resourceConnectedApp() *schema.Resource {
 		ReadContext:   resourceConnectedAppRead,
 		UpdateContext: resourceConnectedAppUpdate,
 		DeleteContext: resourceConnectedAppDelete,
-		CustomizeDiff: customizeDiffConnectedApp,
 		Description: `
 		Creates and manage a ` + "`" + `connected app` + "`" + `.
 		`,
@@ -100,8 +100,9 @@ func resourceConnectedApp() *schema.Resource {
 			},
 			"scope": {
 				Description: "The scopes this connected app has authorization to work on. " +
-					"For `client_credentials` connected apps, scopes are compared as an " +
-					"unordered set, so reordering scope blocks does not produce a diff.",
+					"Do not declare the `profile` scope: Anypoint attaches it automatically to " +
+					"`client_credentials` connected apps, and the Read step filters it out of " +
+					"state, so declaring it in configuration would create a perpetual diff.",
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -109,7 +110,17 @@ func resourceConnectedApp() *schema.Resource {
 						"scope": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Scope",
+							Description: "Scope name. The reserved `profile` scope is not allowed here — it is platform-managed.",
+							ValidateDiagFunc: func(v any, p cty.Path) diag.Diagnostics {
+								if s, ok := v.(string); ok && strings.EqualFold(s, "profile") {
+									return diag.Diagnostics{diag.Diagnostic{
+										Severity: diag.Error,
+										Summary:  "Reserved scope \"profile\" cannot be declared",
+										Detail:   "Anypoint attaches the `profile` scope automatically to `client_credentials` connected apps. The provider strips it from state on Read, so declaring it in configuration produces a perpetual diff. Remove the scope block (or replace it with a real scope name) to fix the plan.",
+									}}
+								}
+								return nil
+							},
 						},
 						"org_id": {
 							Type:        schema.TypeString,
@@ -492,75 +503,6 @@ func newConnectedAppPatchBody(d *schema.ResourceData) *connected_app.ConnectedAp
 		body.SetOwnerUserId(userid.(string))
 	}
 	return body
-}
-
-// customizeDiffConnectedApp clears the `scope` diff when the prior state and
-// configured scopes describe the same set. Using DiffSuppressFunc with
-// d.GetChange("scope") is unreliable for a TypeList of blocks: at diff time
-// the SDK returns (state, state) instead of (state, config), so a removed
-// block is silently dropped. ResourceDiff.GetChange returns (state, config)
-// correctly during CustomizeDiff.
-func customizeDiffConnectedApp(ctx context.Context, d *schema.ResourceDiff, m any) error {
-	if !d.HasChange("scope") {
-		return nil
-	}
-	oldV, newV := d.GetChange("scope")
-	oldList, _ := oldV.([]any)
-	newList, _ := newV.([]any)
-	if connectedAppScopeSetsEqual(oldList, newList) {
-		return d.Clear("scope")
-	}
-	return nil
-}
-
-// connectedAppScopeSetsEqual compares two scope block lists as unordered
-// sets, ignoring the platform-added "profile" scope.
-func connectedAppScopeSetsEqual(a, b []any) bool {
-	a = filterProfileScope(a)
-	b = filterProfileScope(b)
-	if len(a) != len(b) {
-		return false
-	}
-	keys := make(map[string]int, len(a))
-	for _, item := range a {
-		keys[connectedAppScopeKey(item)]++
-	}
-	for _, item := range b {
-		k := connectedAppScopeKey(item)
-		if keys[k] == 0 {
-			return false
-		}
-		keys[k]--
-	}
-	return true
-}
-
-// connectedAppScopeKey returns a stable key for a scope block.
-func connectedAppScopeKey(item any) string {
-	m, _ := item.(map[string]any)
-	scope, _ := m["scope"].(string)
-	orgID, _ := m["org_id"].(string)
-	envID, _ := m["env_id"].(string)
-	return scope + "|" + orgID + "|" + envID
-}
-
-// filterProfileScope removes the platform-added "profile" scope, which
-// Anypoint attaches automatically to "on its own behalf" connected apps.
-func filterProfileScope(scopes []any) []any {
-	out := make([]any, 0, len(scopes))
-	for _, scope := range scopes {
-		m, ok := scope.(map[string]any)
-		if !ok {
-			out = append(out, scope)
-			continue
-		}
-		name, _ := m["scope"].(string)
-		if strings.EqualFold(name, "profile") {
-			continue
-		}
-		out = append(out, scope)
-	}
-	return out
 }
 
 /*

--- a/docs/resources/connected_app.md
+++ b/docs/resources/connected_app.md
@@ -93,7 +93,7 @@ resource "anypoint_connected_app" "my_conn_app_behalf_of_user" {
 - `public_keys` (List of String) Application public key (PEM format). Used to validate JWT authorization grants.
 				Required when grant type jwt-bearer is selected.
 - `redirect_uris` (List of String) Configure which URIs users may be directed to after authorization
-- `scope` (Block List) The scopes this connected app has authorization to work on. For `client_credentials` connected apps, scopes are compared as an unordered set, so reordering scope blocks does not produce a diff. (see [below for nested schema](#nestedblock--scope))
+- `scope` (Block List) The scopes this connected app has authorization to work on. Do not declare the `profile` scope: Anypoint attaches it automatically to `client_credentials` connected apps, and the Read step filters it out of state, so declaring it in configuration would create a perpetual diff. (see [below for nested schema](#nestedblock--scope))
 - `secret` (String, Sensitive) The secret of the connected app.
 - `user_id` (String) The id of the user who owns the connected app. Set to a different user id to transfer ownership; leave unset to keep the platform default (creator on first apply).
 
@@ -109,7 +109,7 @@ resource "anypoint_connected_app" "my_conn_app_behalf_of_user" {
 
 Required:
 
-- `scope` (String) Scope
+- `scope` (String) Scope name. The reserved `profile` scope is not allowed here — it is platform-managed.
 
 Optional:
 


### PR DESCRIPTION
## Summary

- Surfaced during #52 playground testing: `customizeDiffConnectedApp` (added in PR #121 for issue #26) called `d.Clear(\"scope\")` to suppress the spurious diff when state and config differed only by the platform-managed `profile` scope. `d.Clear` (and `d.SetNew`) is restricted by the Terraform plugin SDK to `Computed` keys; `scope` is `Optional` only, so any plan triggered the callback errored with `Error: Clear only operates on computed keys - scope is not one`.
- Making `scope` `Optional+Computed` would regress #26 (silent drop of scope-block removals); the SDK has no non-Computed diff-suppression mechanism for a `TypeList` of nested blocks.
- Pick the user-friendlier branch: reject `profile` in config at plan time via a `ValidateDiagFunc` on the inner `scope.scope` attribute, and drop the broken callback. Read already strips `profile` from state, so declaring it in config was always a perpetual-diff trap — the new error points users straight at the fix.

## Related

- Closes: follow-up to #26 (PR #121)
- Surfaced during: #52 (PR #128) playground testing
- Generator PR: n/a
- `anypoint-client-go/<service>` release tag: n/a

## Type of change

- [x] Bug fix in existing resource / data source

## Behavioral notes

Before:
```hcl
resource \"anypoint_connected_app\" \"x\" {
  ...
  scope { scope = \"profile\" }
}
```
→ first `plan` after apply errors with `Clear only operates on computed keys - scope is not one`. The resource becomes unmanageable.

After:
- Same config → `plan` fails fast with a clear error:
  > Reserved scope \"profile\" cannot be declared
  >
  > Anypoint attaches the `profile` scope automatically to `client_credentials` connected apps. The provider strips it from state on Read, so declaring it in configuration produces a perpetual diff. Remove the scope block (or replace it with a real scope name) to fix the plan.
- Configurations without `profile` continue to plan/apply normally. #26's removal-detection path is preserved by default SDK diff machinery (no suppression callback runs).

## Verification

- `make build` clean.
- `make install` against playground; `terraform plan -target=anypoint_connected_app.case_26` with `scope { scope = \"profile\" }` produces the new validation error.
- `terraform plan` with `scope { scope = \"read:organization\", org_id = ... }` produces a normal Create plan (no spurious diff, no callback error).

## Checklist

### Code

- [x] `gofmt -w anypoint/` clean.
- [x] `make build` passes.
- [x] Dead helpers removed (`customizeDiffConnectedApp`, `connectedAppScopeSetsEqual`, `connectedAppScopeKey`, `filterProfileScope`).

### Docs

- [x] `tfplugindocs generate` regenerated `docs/resources/connected_app.md`.