### PR TITLE
chore(release): bump VERSION to 1.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=anypoint.mulesoft.com
 NAMESPACE=automation
 NAME=anypoint
 BINARY=terraform-provider-${NAME}
-VERSION=1.10.0-SNAPSHOT
+VERSION=1.10.0
 OS_ARCH=darwin_arm64
 
 default: install


### PR DESCRIPTION
## Summary

- Bump `VERSION` in `Makefile` from `1.10.0-SNAPSHOT` to `1.10.0` ahead of the v1.10.0 release tag.
- No code changes; this is the version-pin commit that feeds the subsequent `dev → master` release PR.

## Related

- Tracking doc (gitignored, maintainer-local): `docs/RELEASE_v1.10.0.md`
- Follow-up: open `dev → master` PR titled `Release v1.10.0`, then `gh release create v1.10.0`.

## Release scope landed in this train

| Priority | Issue | PR | Summary |
|---|---|---|---|
| P0 | #17 | #119 | Crash when remote state deleted outside Terraform (graceful 404 → recreate) |
| P1 | #94 | #120 | `team_group_mappings` returned 401 under connected-app auth |
| P1 | #26 | #121 | `connected_app` silently dropped diff when whole `scope` block removed |
| P1 | #61 | #122 | `team_roles` spuriously proposed recreation on every plan |
| P2 | #75 | #123 | `bg` exposed read-only entitlement fields as settable |
| P3 | #21 | #124 | New resource: `anypoint_team_role` (single role assignment on a team) |
| P4 | #60 | #117 | New resource + data sources: `anypoint_api_instance_sla_tier` |
| P4 | #58 | #118 | New resource + data sources: `anypoint_exchange_asset` |
| P5 | #54 | #125 + #126 | `bg` `for_each` parallelism failure (transient retry helper + provider-wide error-body extraction) |
| P5 | #52 | #128 | `connected_app` ownership transfer via `user_id` |
| Follow-up to #26 | — | #129 | Reject reserved `profile` scope at plan time |

## Type of change

- [x] Release / version bump

## Checklist

- [x] `Makefile` `VERSION=1.10.0` (no `-SNAPSHOT`).
- [x] No code changes in this PR.
- [x] `make build` passes (unchanged from current `dev`).