### PR TITLE
release/v1.10.1: bump VERSION + ship #132 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=anypoint.mulesoft.com
 NAMESPACE=automation
 NAME=anypoint
 BINARY=terraform-provider-${NAME}
-VERSION=1.10.0
+VERSION=1.10.1
 OS_ARCH=darwin_arm64
 
 default: install


### PR DESCRIPTION
## Summary

- Bumps \`Makefile\` VERSION \`1.10.0\` → \`1.10.1\`.
- Ships PR #135 (already merged to \`dev\`): soft-deprecation patch for the 44 \`anypoint_bg\` \`entitlement_*\` fields that PR #123 hard-flipped in v1.10.0, breaking existing configurations. See issue #132 for the full report.

## Related

- Closes (when merged + tagged): #132
- Tracker for the hard-flip in v2.0.0: #136

## Type of change

- [x] Bug fix in existing resource / data source
- [x] Dependency / client module bump (Makefile VERSION only)

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`make install\` produces a v1.10.1 plugin binary.
- [x] Playground \`terraform plan\` on a config writing 10 of the soft-deprecated fields plans clean with \`"Argument is deprecated"\` warnings and no \`"Can't configure a value for X"\` errors (see #135 test plan).
- [x] \`grep -n "replace " go.mod\` → no \`anypoint-client-go\` entries.
