### PR TITLE
fix(apim_policy_*): repair enable/disable inversion + sensitive config drift

### DIFF
--- a/anypoint/resource_apim_policy_basic_auth.go
+++ b/anypoint/resource_apim_policy_basic_auth.go
@@ -237,6 +237,10 @@ func resourceApimInstancePolicyBasicAuthRead(ctx context.Context, d *schema.Reso
 
 func resourceApimInstancePolicyBasicAuthUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Capture the planned `disabled` value up front — the mid-Update Read below
+	// rewrites `disabled` in state with the API-returned value, which would flip
+	// the branch in the toggle block at the bottom of this function.
+	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
 	if d.HasChanges("configuration_data", "pointcut_data") {
 		pco := m.(ProviderConfOutput)
@@ -262,8 +266,7 @@ func resourceApimInstancePolicyBasicAuthUpdate(ctx context.Context, d *schema.Re
 		diags = append(diags, resourceApimInstancePolicyBasicAuthRead(ctx, d, m)...)
 	}
 	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
+		if plannedDisabled {
 			diags = append(diags, disableApimInstancePolicyBasicAuth(ctx, d, m)...)
 		} else {
 			diags = append(diags, enableApimInstancePolicyBasicAuth(ctx, d, m)...)

--- a/anypoint/resource_apim_policy_client_id_enforcement.go
+++ b/anypoint/resource_apim_policy_client_id_enforcement.go
@@ -257,6 +257,10 @@ func resourceApimInstancePolicyClientIdEnfRead(ctx context.Context, d *schema.Re
 
 func resourceApimInstancePolicyClientIdEnfUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Capture the planned `disabled` value up front — the mid-Update Read below
+	// rewrites `disabled` in state with the API-returned value, which would flip
+	// the branch in the toggle block at the bottom of this function.
+	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
 	if d.HasChanges("configuration_data", "pointcut_data") {
 		pco := m.(ProviderConfOutput)
@@ -282,8 +286,7 @@ func resourceApimInstancePolicyClientIdEnfUpdate(ctx context.Context, d *schema.
 		diags = append(diags, resourceApimInstancePolicyClientIdEnfRead(ctx, d, m)...)
 	}
 	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
+		if plannedDisabled {
 			diags = append(diags, disableApimInstancePolicyClientIdEnf(ctx, d, m)...)
 		} else {
 			diags = append(diags, enableApimInstancePolicyClientIdEnf(ctx, d, m)...)

--- a/anypoint/resource_apim_policy_custom.go
+++ b/anypoint/resource_apim_policy_custom.go
@@ -315,6 +315,10 @@ func resourceApimInstancePolicyCustomRead(ctx context.Context, d *schema.Resourc
 
 func resourceApimInstancePolicyCustomUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Capture the planned `disabled` value up front — the mid-Update Read below
+	// rewrites `disabled` in state with the API-returned value, which would flip
+	// the branch in the toggle block at the bottom of this function.
+	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
 	if d.HasChanges("configuration_data", "pointcut_data") {
 		pco := m.(ProviderConfOutput)
@@ -349,8 +353,7 @@ func resourceApimInstancePolicyCustomUpdate(ctx context.Context, d *schema.Resou
 		diags = append(diags, resourceApimInstancePolicyCustomRead(ctx, d, m)...)
 	}
 	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
+		if plannedDisabled {
 			diags = append(diags, disableApimInstancePolicyCustom(ctx, d, m)...)
 		} else {
 			diags = append(diags, enableApimInstancePolicyCustom(ctx, d, m)...)
@@ -433,15 +436,23 @@ func disableApimInstancePolicyCustom(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
+// flattenApimPolicyCustomCfg merges the API-returned `configurationData` over the
+// declared `configuration_data` from prior state. Sensitive fields (e.g. clientId,
+// clientSecret) are not returned by the GET endpoint, so falling back to the prior
+// declared values prevents perpetual `+` drift on every plan.
 func flattenApimPolicyCustomCfg(d *schema.ResourceData, policy *apim_policy.ApimPolicy) (string, error) {
 	data := policy.GetConfigurationData()
-	var dst map[string]any
-	err := json.Unmarshal([]byte(d.Get("configuration_data").(string)), &dst)
-	if err != nil {
-		return "", fmt.Errorf("configuration_data expected to be a valid JSON Object. %s", err.Error())
+	dst := make(map[string]any)
+	if raw, ok := d.Get("configuration_data").(string); ok && raw != "" {
+		if err := json.Unmarshal([]byte(raw), &dst); err != nil {
+			return "", fmt.Errorf("configuration_data expected to be a valid JSON Object. %s", err.Error())
+		}
 	}
 	maps.Copy(dst, data)
-	b, _ := json.Marshal(data)
+	b, err := json.Marshal(dst)
+	if err != nil {
+		return "", fmt.Errorf("unable to marshal merged configuration_data. %s", err.Error())
+	}
 	return string(b), nil
 }
 

--- a/anypoint/resource_apim_policy_jwt_validation.go
+++ b/anypoint/resource_apim_policy_jwt_validation.go
@@ -473,6 +473,10 @@ func resourceApimInstancePolicyJwtValidationRead(ctx context.Context, d *schema.
 
 func resourceApimInstancePolicyJwtValidationUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Capture the planned `disabled` value up front — the mid-Update Read below
+	// rewrites `disabled` in state with the API-returned value, which would flip
+	// the branch in the toggle block at the bottom of this function.
+	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
 	if d.HasChanges("configuration_data", "pointcut_data") {
 		pco := m.(ProviderConfOutput)
@@ -498,8 +502,7 @@ func resourceApimInstancePolicyJwtValidationUpdate(ctx context.Context, d *schem
 		diags = append(diags, resourceApimInstancePolicyJwtValidationRead(ctx, d, m)...)
 	}
 	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
+		if plannedDisabled {
 			diags = append(diags, disableApimInstancePolicyJwtValidation(ctx, d, m)...)
 		} else {
 			diags = append(diags, enableApimInstancePolicyJwtValidation(ctx, d, m)...)

--- a/anypoint/resource_apim_policy_message_logging.go
+++ b/anypoint/resource_apim_policy_message_logging.go
@@ -292,6 +292,10 @@ func resourceApimInstancePolicyMessageLoggingRead(ctx context.Context, d *schema
 
 func resourceApimInstancePolicyMessageLoggingUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Capture the planned `disabled` value up front — the mid-Update Read below
+	// rewrites `disabled` in state with the API-returned value, which would flip
+	// the branch in the toggle block at the bottom of this function.
+	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
 	if d.HasChanges("configuration_data", "pointcut_data") {
 		pco := m.(ProviderConfOutput)
@@ -317,8 +321,7 @@ func resourceApimInstancePolicyMessageLoggingUpdate(ctx context.Context, d *sche
 		diags = append(diags, resourceApimInstancePolicyMessageLoggingRead(ctx, d, m)...)
 	}
 	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
+		if plannedDisabled {
 			diags = append(diags, disableApimInstancePolicyMessageLogging(ctx, d, m)...)
 		} else {
 			diags = append(diags, enableApimInstancePolicyMessageLogging(ctx, d, m)...)

--- a/anypoint/resource_apim_policy_rate_limit.go
+++ b/anypoint/resource_apim_policy_rate_limit.go
@@ -278,6 +278,10 @@ func resourceApimInstancePolicyRateLimitingRead(ctx context.Context, d *schema.R
 
 func resourceApimInstancePolicyRateLimitingUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	var diags diag.Diagnostics
+	// Capture the planned `disabled` value up front — the mid-Update Read below
+	// rewrites `disabled` in state with the API-returned value, which would flip
+	// the branch in the toggle block at the bottom of this function.
+	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
 	if d.HasChanges("configuration_data", "pointcut_data") {
 		pco := m.(ProviderConfOutput)
@@ -303,8 +307,7 @@ func resourceApimInstancePolicyRateLimitingUpdate(ctx context.Context, d *schema
 		diags = append(diags, resourceApimInstancePolicyRateLimitingRead(ctx, d, m)...)
 	}
 	if d.HasChange("disabled") {
-		disabled := d.Get("disabled").(bool)
-		if disabled {
+		if plannedDisabled {
 			diags = append(diags, disableApimInstancePolicyRateLimiting(ctx, d, m)...)
 		} else {
 			diags = append(diags, enableApimInstancePolicyRateLimiting(ctx, d, m)...)


### PR DESCRIPTION
## Summary

- Closes #143 — `apim_policy_*` Update flow inverts enable/disable because the mid-Update Read rewrites `disabled` in state before the toggle branch reads it. Affects every variant (`custom`, `basic_auth`, `client_id_enforcement`, `jwt_validation`, `message_logging`, `rate_limit`).
- Closes #144 — `apim_policy_custom`'s `flattenApimPolicyCustomCfg` marshals the wrong map, so declared sensitive fields (e.g. `clientId`, `clientSecret` on `credential-injection-oauth2-obo`) drop out of state on every Read and the next plan re-adds them perpetually.

## #143 fix

For every variant: capture `plannedDisabled := d.Get("disabled").(bool)` at the top of `Update` — before any Read can run — and branch on the captured value inside `if d.HasChange("disabled")`. Same one-line pattern in all six files. Same comment on each so the rationale travels with the code.

## #144 fix

Two-part change to `flattenApimPolicyCustomCfg`:

1. Marshal `dst` (the merged map of declared + API-returned values) instead of `data` (API-returned only). The existing `maps.Copy(dst, data)` already did the right merge; the marshal target was wrong.
2. Tighten the JSON unmarshal guard for empty state and surface a real error if `json.Marshal` somehow fails.

Other variants' flatten functions return `map[string]any` directly and never had the marshal-target bug — left untouched.

## Verification

Bug-bash playground case (`case_bugbash.tf`) drives a Mule4 instance + outbound OBO custom policy through the live US control plane. Same token used end-to-end.

| Step | Expected | Actual |
|---|---|---|
| Apply create (disabled=false) | Policy id returned, `disabled=false` on API | ✅ |
| Plan after create | No changes (no sensitive-field drift) | ✅ #144 — was `+ clientId / + clientSecret` on every plan before |
| Toggle disabled=false → true | Disable dispatched, API returns `disabled=true` | ✅ #143 — was 400 "already enabled" before |
| Toggle disabled=true → false | Enable dispatched, API returns `disabled=false` | ✅ |
| Combined PATCH (scope change) + disable=true | PATCH applies, then disable dispatches correctly | ✅ original #143 trigger from #139 verification |
| Destroy + state cleanup | Clean | ✅ HARD rule |

## Scope

PR is intentionally tight: only the two bugs above. The pattern fix is mechanical (`d.Get("disabled")` capture moved up by ~15 lines) and lands the same way in all six variant files; reviewers can confirm by diffing any one variant against the others.

## Milestone

v1.11.0.