### PR TITLE
feat(apim_policy_custom): plan-time JSON Schema validation + in-place asset_version upgrade

### DIFF
--- a/anypoint/policy_template_cache.go
+++ b/anypoint/policy_template_cache.go
@@ -1,0 +1,192 @@
+package anypoint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// policyTemplateEntry is what we cache per (group, asset, version) — the parsed
+// configuration JSON Schema (nil when the template carries no schema).
+type policyTemplateEntry struct {
+	Schema *jsonschema.Schema
+}
+
+var policyTemplateCache sync.Map // key: "{group}/{asset}/{version}" → *policyTemplateEntry
+
+func policyTemplateCacheKey(group, asset, version string) string {
+	return group + "/" + asset + "/" + version
+}
+
+// loadPolicyTemplateCached fetches a single policy template via xapi/v1 and
+// returns the cached entry. Cache lives for the lifetime of the provider
+// process. Returns an entry with a nil Schema when the template carries no
+// JSON Schema (legacy mule3 / older mule4 policies expose a property list
+// instead of a JSON Schema object).
+func loadPolicyTemplateCached(
+	ctx context.Context,
+	pco *ProviderConfOutput,
+	orgId, assetGroupId, assetId, assetVersion string,
+) (*policyTemplateEntry, diag.Diagnostics) {
+	key := policyTemplateCacheKey(assetGroupId, assetId, assetVersion)
+	if v, ok := policyTemplateCache.Load(key); ok {
+		return v.(*policyTemplateEntry), nil
+	}
+
+	authctx := getApimPolicyAuthCtx(ctx, pco)
+	res, httpr, err := pco.apimpolicyclient.DefaultAPI.
+		GetOrgExchangePolicyTemplateDetails(authctx, orgId, assetGroupId, assetId, assetVersion).
+		SplitModel(true).
+		Execute()
+	if err != nil {
+		details := extractAPIErrorDetail(err, httpr)
+		return nil, diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Unable to fetch policy template %s/%s/%s for plan-time validation", assetGroupId, assetId, assetVersion),
+			Detail:   details,
+		}}
+	}
+	if httpr != nil && httpr.Body != nil {
+		defer httpr.Body.Close()
+	}
+
+	entry := &policyTemplateEntry{}
+	if cfg := res.GetConfiguration(); cfg != nil {
+		// Configuration is `interface{}` — could be a JSON Schema object (modern
+		// split-asset policies) or an array of PolicyConfiguration items (legacy
+		// policies). We only compile when it is an object.
+		if _, ok := cfg.(map[string]any); ok {
+			b, mErr := json.Marshal(cfg)
+			if mErr != nil {
+				return nil, diag.Diagnostics{{
+					Severity: diag.Error,
+					Summary:  fmt.Sprintf("Unable to marshal policy template %s/%s/%s configuration schema", assetGroupId, assetId, assetVersion),
+					Detail:   mErr.Error(),
+				}}
+			}
+			compiler := jsonschema.NewCompiler()
+			compiler.Draft = jsonschema.Draft2019
+			if cErr := compiler.AddResource("config.json", strings.NewReader(string(b))); cErr != nil {
+				return nil, diag.Diagnostics{{
+					Severity: diag.Error,
+					Summary:  fmt.Sprintf("Unable to load policy template %s/%s/%s configuration schema", assetGroupId, assetId, assetVersion),
+					Detail:   cErr.Error(),
+				}}
+			}
+			schema, cErr := compiler.Compile("config.json")
+			if cErr != nil {
+				return nil, diag.Diagnostics{{
+					Severity: diag.Error,
+					Summary:  fmt.Sprintf("Unable to compile policy template %s/%s/%s configuration schema", assetGroupId, assetId, assetVersion),
+					Detail:   cErr.Error(),
+				}}
+			}
+			entry.Schema = schema
+		}
+	}
+
+	policyTemplateCache.Store(key, entry)
+	return entry, nil
+}
+
+// validateConfigAgainstSchema parses the configuration_data JSON string and
+// validates it against the compiled schema. Returns a diag.Diagnostics with
+// one entry per validation failure when invalid.
+func validateConfigAgainstSchema(configJSON string, schema *jsonschema.Schema, assetCoord string) diag.Diagnostics {
+	if schema == nil {
+		// Legacy policy template with no schema — nothing to validate at plan time.
+		return nil
+	}
+	if strings.TrimSpace(configJSON) == "" {
+		return nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(configJSON), &parsed); err != nil {
+		return diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Invalid configuration_data for %s: not valid JSON", assetCoord),
+			Detail:   err.Error(),
+		}}
+	}
+	if err := schema.Validate(parsed); err != nil {
+		return flattenJSONSchemaError(err, assetCoord)
+	}
+	return nil
+}
+
+// flattenJSONSchemaError walks a santhosh-tekuri ValidationError tree and
+// emits one diag.Error per leaf so users see a per-field message instead of
+// a single dense wrapped error.
+func flattenJSONSchemaError(err error, assetCoord string) diag.Diagnostics {
+	verr, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  "configuration_data failed schema validation for " + assetCoord,
+			Detail:   err.Error(),
+		}}
+	}
+	var diags diag.Diagnostics
+	for _, leaf := range collectLeafErrors(verr) {
+		path := leaf.InstanceLocation
+		if path == "" {
+			path = "/"
+		}
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("configuration_data invalid for %s at %s", assetCoord, path),
+			Detail:   leaf.Message,
+		})
+	}
+	if len(diags) == 0 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "configuration_data failed schema validation for " + assetCoord,
+			Detail:   verr.Error(),
+		})
+	}
+	return diags
+}
+
+func collectLeafErrors(v *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if v == nil {
+		return nil
+	}
+	if len(v.Causes) == 0 {
+		return []*jsonschema.ValidationError{v}
+	}
+	var out []*jsonschema.ValidationError
+	for _, c := range v.Causes {
+		out = append(out, collectLeafErrors(c)...)
+	}
+	return out
+}
+
+// diagsToError flattens a diag.Diagnostics into a plain error for use inside
+// CustomizeDiff (which only accepts error). Concatenates summary + detail per
+// diag with "; " separator. Drops non-Error severities.
+func diagsToError(diags diag.Diagnostics) error {
+	if len(diags) == 0 {
+		return nil
+	}
+	var parts []string
+	for _, d := range diags {
+		if d.Severity != diag.Error {
+			continue
+		}
+		if d.Detail != "" {
+			parts = append(parts, fmt.Sprintf("%s: %s", d.Summary, d.Detail))
+		} else {
+			parts = append(parts, d.Summary)
+		}
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", strings.Join(parts, "; "))
+}

--- a/anypoint/resource_apim_policy_custom.go
+++ b/anypoint/resource_apim_policy_custom.go
@@ -20,8 +20,12 @@ func resourceApimInstancePolicyCustom() *schema.Resource {
 		ReadContext:   resourceApimInstancePolicyCustomRead,
 		UpdateContext: resourceApimInstancePolicyCustomUpdate,
 		DeleteContext: resourceApimInstancePolicyCustomDelete,
+		CustomizeDiff: resourceApimInstancePolicyCustomCustomizeDiff,
 		Description: `
-		Create and manage an API Policy of any type.
+		Create and manage an API Policy of any type. The supplied ` + "`configuration_data`" + ` is
+		validated against the policy template's published JSON Schema at plan time when
+		the template exposes one, so configuration errors surface before ` + "`terraform apply`" + `.
+		` + "`asset_version`" + ` changes are applied in place — no resource replacement.
 		`,
 		Schema: map[string]*schema.Schema{
 			"last_updated": {
@@ -128,8 +132,7 @@ func resourceApimInstancePolicyCustom() *schema.Resource {
 			"asset_version": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "the policy template version in anypoint exchange.",
+				Description: "The policy template version in Anypoint Exchange. Changing this value upgrades the policy in place via PATCH — no resource replacement. Validated against the new template's published JSON Schema at plan time.",
 			},
 			"injection_point": {
 				Type:         schema.TypeString,
@@ -156,6 +159,54 @@ func resourceApimInstancePolicyCustom() *schema.Resource {
 // isOutboundPolicy reports whether the resource is configured to use the outbound endpoint family.
 func isOutboundPolicy(d *schema.ResourceData) bool {
 	return d.Get("injection_point").(string) == "outbound"
+}
+
+// resourceApimInstancePolicyCustomCustomizeDiff runs plan-time validation of
+// `configuration_data` against the policy template's published JSON Schema and
+// of the `injection_point` / `upstream_id` invariants. Legacy templates with
+// no JSON Schema (mule3 / older mule4) are skipped — there is nothing to
+// validate against.
+func resourceApimInstancePolicyCustomCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, m any) error {
+	if m == nil {
+		return nil
+	}
+	pco, ok := m.(ProviderConfOutput)
+	if !ok {
+		return nil
+	}
+
+	injectionPoint, _ := d.Get("injection_point").(string)
+	upstreamId, _ := d.Get("upstream_id").(string)
+	if injectionPoint == "outbound" && upstreamId == "" && d.NewValueKnown("upstream_id") {
+		return fmt.Errorf("upstream_id is required when injection_point = \"outbound\"")
+	}
+	if injectionPoint == "inbound" && upstreamId != "" {
+		return fmt.Errorf("upstream_id must be empty when injection_point = \"inbound\"")
+	}
+
+	orgId, _ := d.Get("org_id").(string)
+	assetGroupId, _ := d.Get("asset_group_id").(string)
+	assetId, _ := d.Get("asset_id").(string)
+	assetVersion, _ := d.Get("asset_version").(string)
+	configJSON, _ := d.Get("configuration_data").(string)
+	if orgId == "" || assetGroupId == "" || assetId == "" || assetVersion == "" {
+		return nil
+	}
+	if !d.NewValueKnown("configuration_data") || !d.NewValueKnown("asset_version") {
+		return nil
+	}
+	entry, diags := loadPolicyTemplateCached(ctx, &pco, orgId, assetGroupId, assetId, assetVersion)
+	if diags.HasError() {
+		return diagsToError(diags)
+	}
+	if entry == nil || entry.Schema == nil {
+		return nil
+	}
+	assetCoord := assetGroupId + "/" + assetId + "/" + assetVersion
+	if vdiags := validateConfigAgainstSchema(configJSON, entry.Schema, assetCoord); vdiags.HasError() {
+		return diagsToError(vdiags)
+	}
+	return nil
 }
 
 func resourceApimInstancePolicyCustomCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
@@ -320,7 +371,7 @@ func resourceApimInstancePolicyCustomUpdate(ctx context.Context, d *schema.Resou
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data") {
+	if d.HasChanges("configuration_data", "pointcut_data", "asset_version") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)

--- a/docs/resources/apim_policy_custom.md
+++ b/docs/resources/apim_policy_custom.md
@@ -3,12 +3,18 @@
 page_title: "anypoint_apim_policy_custom Resource - terraform-provider-anypoint"
 subcategory: ""
 description: |-
-  Create and manage an API Policy of any type.
+  Create and manage an API Policy of any type. The supplied `configuration_data` is
+  	validated against the policy template's published JSON Schema at plan time when
+  	the template exposes one, so configuration errors surface before `terraform apply`.
+  	`asset_version` changes are applied in place — no resource replacement.
 ---
 
 # anypoint_apim_policy_custom (Resource)
 
-Create and manage an API Policy of any type.
+Create and manage an API Policy of any type. The supplied `configuration_data` is
+		validated against the policy template's published JSON Schema at plan time when
+		the template exposes one, so configuration errors surface before `terraform apply`.
+		`asset_version` changes are applied in place — no resource replacement.
 
 ## Example Usage
 
@@ -196,7 +202,7 @@ resource "anypoint_apim_policy_custom" "policy_custom_06_outbound_obo" {
 - `apim_id` (String) The api manager instance id where the api instance is defined.
 - `asset_group_id` (String) The policy template group id in anypoint exchange. Don't change unless mulesoft has renamed the policy group id.
 - `asset_id` (String) The policy template id in anypoint exchange. Don't change unless mulesoft has renamed the policy asset id.
-- `asset_version` (String) the policy template version in anypoint exchange.
+- `asset_version` (String) The policy template version in Anypoint Exchange. Changing this value upgrades the policy in place via PATCH — no resource replacement. Validated against the new template's published JSON Schema at plan time.
 - `configuration_data` (String) The policy configuration data in json format
 - `env_id` (String) The environment id where api instance is defined.
 - `org_id` (String) The organization id where the api instance is defined.

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,10 @@ require (
 	github.com/mulesoft-anypoint/anypoint-client-go/vpn v0.1.0
 )
 
-require github.com/mulesoft-anypoint/anypoint-client-go/exchange_assets v0.0.4
+require (
+	github.com/mulesoft-anypoint/anypoint-client-go/exchange_assets v0.0.4
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+)
 
 require gopkg.in/validator.v2 v2.0.1 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
## Summary

Two-part enhancement to the existing **`anypoint_apim_policy_custom`** resource:

1. **Drops `ForceNew` from `asset_version`** — version changes PATCH the policy in place instead of forcing replacement.
2. **Wires a `CustomizeDiff` that validates `configuration_data` against the policy template's published JSON Schema at plan time.** Errors surface as `Error: configuration_data invalid for <coord> at /<json_pointer>: <reason>` during `terraform plan`, not as opaque HTTP 400s during `terraform apply`.

Replaces the closed #147 — extends the existing resource in place rather than introducing a parallel `anypoint_apim_policy`. See the closing comment on #147 for the rationale.

Part of v1.11.0 P0 row #2. Foundation for the v1.11 AI strand composites (`ai_gateway`, `agent_stack`, `mcp_server_proxy`).

## Validator flow

1. `CustomizeDiff` reads `org_id`, `asset_group_id`, `asset_id`, `asset_version`, `configuration_data`, `injection_point`, `upstream_id` from the diff.
2. Validates `injection_point + upstream_id` invariants (outbound requires `upstream_id`; inbound forbids it).
3. Calls `loadPolicyTemplateCached` — `GetOrgExchangePolicyTemplateDetails` via xapi/v1 with `splitModel=true`. Cached per process in `sync.Map` keyed by `{group}/{asset}/{version}`.
4. When the template returns a JSON Schema object (modern split-asset policies — AI/MCP/A2A/credential-injection), compiles via `santhosh-tekuri/jsonschema/v5` (draft-2019-09).
5. Validates the parsed `configuration_data` against the compiled schema. Emits one `diag.Error` per leaf failure with the JSON Pointer to the offending field.
6. Legacy templates (mule3 / older mule4) expose a `PolicyConfiguration` list instead of a JSON Schema — those skip validation gracefully.

## Why extend `_custom` instead of new resource

Closed #147 introduced a parallel `anypoint_apim_policy`. Schema turned out to be byte-identical with `_custom` aside from the `asset_version` ForceNew flip. That meant:

- 400 lines of duplicated CRUD
- Every existing user forced through `terraform state mv` to migrate
- Permanent "two-ways-to-do-the-same-thing" axis in the docs
- Deprecation warning on `_custom` for years

This PR drops all of that and lands the validation in the existing resource. The rename to `anypoint_apim_policy` (to match official MuleSoft provider naming) is filed as a separate decision — should be done with state-migration tooling, not piggybacked on a validation feature.

## Scope cuts vs the design doc (filed as follow-ups)

| Design item | Decision |
|---|---|
| `configuration` as `TypeMap` HCL block | **Cut** — keep `configuration_data` JSON string. Design itself flags TypeMap insufficient for if/then/else schemas. |
| Version-diff classifier inside the resource | **Cut** — use `anypoint_exchange_asset_version_drift` (PR #146) compositionally instead. |
| `injection_point ∈ supportedInjectionPoints` cross-check | **Cut** — `ExchangePolicyTemplate` model lacks `capabilities.injectionPoint`. Spec patch + client release follow-up. |
| Acceptance tests across representative policies | **Deferred** — TF_ACC infra is own PR. |

## Verification (live US control plane)

| Case | Inputs | Result |
|---|---|---|
| Good inbound | `client-id-enforcement@1.3.3` valid config | Created, id returned |
| Good outbound | `credential-injection-oauth2-obo@1.1.1` + `injection_point=outbound` + `upstream_id` | Created, id returned |
| Bad inbound | `clientIdExpression` supplied as `["..."]` instead of string | **Plan-time error**: `configuration_data invalid for 68ef9520.../client-id-enforcement/1.3.3 at /clientIdExpression: expected string, but got array` |
| In-place version upgrade | `asset_version` change `1.3.3 → 1.3.2` | Plans as `~ update in-place` (no replacement) |
| Destroy + cleanup | | Clean |

## Dependencies added

- `github.com/santhosh-tekuri/jsonschema/v5 v5.3.1`

## Files

- `anypoint/resource_apim_policy_custom.go` — drop ForceNew on asset_version; add CustomizeDiff; extend `HasChanges` with `asset_version` so the PATCH fires on version bump.
- `anypoint/policy_template_cache.go` (new) — `sync.Map` template cache + JSON Schema compiler + leaf-error flattener + `diagsToError` helper.
- `docs/resources/apim_policy_custom.md` — regenerated.

## Follow-ups

- File issue: spec patch on `apim_policy` to expose `ExchangePolicyTemplate.capabilities.injectionPoint`.
- File issue: acceptance tests across the policy fleet.
- File issue: rename `_custom → anypoint_apim_policy` deliberately with state-migration tooling.

## Milestone

v1.11.0.