### PR TITLE
feat(apim_policy_*): user-settable execution order

### DIFF
--- a/anypoint/resource_apim_policy_basic_auth.go
+++ b/anypoint/resource_apim_policy_basic_auth.go
@@ -88,8 +88,9 @@ func resourceApimInstancePolicyBasicAuth() *schema.Resource {
 			},
 			"order": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				Computed:    true,
-				Description: "The policy order.",
+				Description: "The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.",
 			},
 			"disabled": {
 				Type:        schema.TypeBool,
@@ -242,7 +243,7 @@ func resourceApimInstancePolicyBasicAuthUpdate(ctx context.Context, d *schema.Re
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data") {
+	if d.HasChanges("configuration_data", "pointcut_data", "order") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)
@@ -365,6 +366,9 @@ func newApimPolicyBasicAuthBody(d *schema.ResourceData) *apim_policy.ApimPolicyB
 	if val, ok := d.GetOk("asset_version"); ok {
 		body.SetAssetVersion(val.(string))
 	}
+	if val, ok := d.GetOk("order"); ok {
+		body.SetOrder(int32(val.(int)))
+	}
 	return body
 }
 
@@ -394,6 +398,9 @@ func newApimPolicyBasicAuthPatchBody(d *schema.ResourceData) map[string]any {
 	}
 	if val, ok := d.GetOk("asset_version"); ok {
 		body["assetVersion"] = val
+	}
+	if val, ok := d.GetOk("order"); ok {
+		body["order"] = int32(val.(int))
 	}
 	return body
 }

--- a/anypoint/resource_apim_policy_client_id_enforcement.go
+++ b/anypoint/resource_apim_policy_client_id_enforcement.go
@@ -105,8 +105,9 @@ func resourceApimInstancePolicyClientIdEnf() *schema.Resource {
 			},
 			"order": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				Computed:    true,
-				Description: "The policy order.",
+				Description: "The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.",
 			},
 			"disabled": {
 				Type:        schema.TypeBool,
@@ -262,7 +263,7 @@ func resourceApimInstancePolicyClientIdEnfUpdate(ctx context.Context, d *schema.
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data") {
+	if d.HasChanges("configuration_data", "pointcut_data", "order") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)
@@ -386,6 +387,9 @@ func newApimPolicyClientIdEnfBody(d *schema.ResourceData) *apim_policy.ApimPolic
 	if val, ok := d.GetOk("asset_version"); ok {
 		body.SetAssetVersion(val.(string))
 	}
+	if val, ok := d.GetOk("order"); ok {
+		body.SetOrder(int32(val.(int)))
+	}
 	return body
 }
 
@@ -416,6 +420,9 @@ func newApimPolicyClientIdEnfPatchBody(d *schema.ResourceData) map[string]any {
 	}
 	if val, ok := d.GetOk("asset_version"); ok {
 		body["assetVersion"] = val
+	}
+	if val, ok := d.GetOk("order"); ok {
+		body["order"] = int32(val.(int))
 	}
 	return body
 }

--- a/anypoint/resource_apim_policy_custom.go
+++ b/anypoint/resource_apim_policy_custom.go
@@ -80,8 +80,9 @@ func resourceApimInstancePolicyCustom() *schema.Resource {
 			},
 			"order": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				Computed:    true,
-				Description: "The policy order.",
+				Description: "The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH. For outbound policies the value is applied via a follow-up PATCH after Create — the outbound POST endpoint does not accept `order` in its body.",
 			},
 			"disabled": {
 				Type:        schema.TypeBool,
@@ -292,6 +293,26 @@ func resourceApimInstancePolicyCustomCreate(ctx context.Context, d *schema.Resou
 	}
 	defer httpr.Body.Close()
 	d.SetId(strconv.Itoa(int(id)))
+	// Outbound POST body cannot carry `order` — patch it in afterwards when the user
+	// declared one, so a single `apply` lands the resource at the desired position.
+	if isOutboundPolicy(d) {
+		if val, ok := d.GetOk("order"); ok {
+			patchBody := map[string]any{"order": int32(val.(int))}
+			_, phttpr, perr := api.PatchApimPolicy(authctx, orgid, envid, apimid, strconv.Itoa(int(id))).Body(patchBody).Execute()
+			if perr != nil {
+				details := extractAPIErrorDetail(perr, phttpr)
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Unable to apply order to outbound custom policy " + strconv.Itoa(int(id)) + " for api " + apimid,
+					Detail:   details,
+				})
+				return diags
+			}
+			if phttpr != nil {
+				phttpr.Body.Close()
+			}
+		}
+	}
 	diags = append(diags, resourceApimInstancePolicyCustomRead(ctx, d, m)...)
 	//in case disabled
 	disabled := d.Get("disabled").(bool)
@@ -371,7 +392,7 @@ func resourceApimInstancePolicyCustomUpdate(ctx context.Context, d *schema.Resou
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data", "asset_version") {
+	if d.HasChanges("configuration_data", "pointcut_data", "asset_version", "order") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)
@@ -553,6 +574,9 @@ func newApimPolicyCustomBody(d *schema.ResourceData) (*apim_policy.ApimPolicyBod
 	if val, ok := d.GetOk("asset_version"); ok {
 		body.SetAssetVersion(val.(string))
 	}
+	if val, ok := d.GetOk("order"); ok {
+		body.SetOrder(int32(val.(int)))
+	}
 	return body, nil
 }
 
@@ -585,6 +609,9 @@ func newApimPolicyCustomPatchBody(d *schema.ResourceData) (map[string]any, error
 	}
 	if val, ok := d.GetOk("asset_version"); ok {
 		body["assetVersion"] = val
+	}
+	if val, ok := d.GetOk("order"); ok {
+		body["order"] = int32(val.(int))
 	}
 	return body, nil
 }

--- a/anypoint/resource_apim_policy_jwt_validation.go
+++ b/anypoint/resource_apim_policy_jwt_validation.go
@@ -321,8 +321,9 @@ func resourceApimInstancePolicyJwtValidation() *schema.Resource {
 			},
 			"order": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				Computed:    true,
-				Description: "The policy order.",
+				Description: "The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.",
 			},
 			"disabled": {
 				Type:        schema.TypeBool,
@@ -478,7 +479,7 @@ func resourceApimInstancePolicyJwtValidationUpdate(ctx context.Context, d *schem
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data") {
+	if d.HasChanges("configuration_data", "pointcut_data", "order") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)
@@ -618,6 +619,9 @@ func newApimPolicyJwtValidationBody(d *schema.ResourceData) *apim_policy.ApimPol
 	if val, ok := d.GetOk("asset_version"); ok {
 		body.SetAssetVersion(val.(string))
 	}
+	if val, ok := d.GetOk("order"); ok {
+		body.SetOrder(int32(val.(int)))
+	}
 	return body
 }
 
@@ -648,6 +652,9 @@ func newApimPolicyJwtValidationPatchBody(d *schema.ResourceData) map[string]any 
 	}
 	if val, ok := d.GetOk("asset_version"); ok {
 		body["assetVersion"] = val
+	}
+	if val, ok := d.GetOk("order"); ok {
+		body["order"] = int32(val.(int))
 	}
 	return body
 }

--- a/anypoint/resource_apim_policy_message_logging.go
+++ b/anypoint/resource_apim_policy_message_logging.go
@@ -143,8 +143,9 @@ func resourceApimInstancePolicyMessageLogging() *schema.Resource {
 			},
 			"order": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				Computed:    true,
-				Description: "The policy order.",
+				Description: "The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.",
 			},
 			"disabled": {
 				Type:        schema.TypeBool,
@@ -297,7 +298,7 @@ func resourceApimInstancePolicyMessageLoggingUpdate(ctx context.Context, d *sche
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data") {
+	if d.HasChanges("configuration_data", "pointcut_data", "order") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)
@@ -447,6 +448,9 @@ func newApimPolicyMessageLoggingBody(d *schema.ResourceData) *apim_policy.ApimPo
 	if val, ok := d.GetOk("asset_version"); ok {
 		body.SetAssetVersion(val.(string))
 	}
+	if val, ok := d.GetOk("order"); ok {
+		body.SetOrder(int32(val.(int)))
+	}
 	return body
 }
 
@@ -477,6 +481,9 @@ func newApimPolicyMessageLoggingPatchBody(d *schema.ResourceData) map[string]any
 	}
 	if val, ok := d.GetOk("asset_version"); ok {
 		body["assetVersion"] = val
+	}
+	if val, ok := d.GetOk("order"); ok {
+		body["order"] = int32(val.(int))
 	}
 	return body
 }

--- a/anypoint/resource_apim_policy_rate_limit.go
+++ b/anypoint/resource_apim_policy_rate_limit.go
@@ -128,8 +128,9 @@ func resourceApimInstancePolicyRateLimiting() *schema.Resource {
 			},
 			"order": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				Computed:    true,
-				Description: "The policy order.",
+				Description: "The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.",
 			},
 			"disabled": {
 				Type:        schema.TypeBool,
@@ -283,7 +284,7 @@ func resourceApimInstancePolicyRateLimitingUpdate(ctx context.Context, d *schema
 	// the branch in the toggle block at the bottom of this function.
 	plannedDisabled := d.Get("disabled").(bool)
 	//detect change
-	if d.HasChanges("configuration_data", "pointcut_data") {
+	if d.HasChanges("configuration_data", "pointcut_data", "order") {
 		pco := m.(ProviderConfOutput)
 		orgid := d.Get("org_id").(string)
 		envid := d.Get("env_id").(string)
@@ -437,6 +438,9 @@ func newApimPolicyRateLimitingBody(d *schema.ResourceData) *apim_policy.ApimPoli
 	if val, ok := d.GetOk("asset_version"); ok {
 		body.SetAssetVersion(val.(string))
 	}
+	if val, ok := d.GetOk("order"); ok {
+		body.SetOrder(int32(val.(int)))
+	}
 	return body
 }
 
@@ -467,6 +471,9 @@ func newApimPolicyRateLimitingPatchBody(d *schema.ResourceData) map[string]any {
 	}
 	if val, ok := d.GetOk("asset_version"); ok {
 		body["assetVersion"] = val
+	}
+	if val, ok := d.GetOk("order"); ok {
+		body["order"] = int32(val.(int))
 	}
 	return body
 }

--- a/docs/resources/apim_policy_basic_auth.md
+++ b/docs/resources/apim_policy_basic_auth.md
@@ -64,6 +64,7 @@ resource "anypoint_apim_policy_basic_auth" "policy02" {
 - `asset_version` (String) the policy template version in anypoint exchange.
 - `disabled` (Boolean) Whether the policy is disabled.
 - `last_updated` (String) The last time this resource has been updated locally.
+- `order` (Number) The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.
 - `pointcut_data` (Block List) The Method & resource conditions (see [below for nested schema](#nestedblock--pointcut_data))
 
 ### Read-Only
@@ -71,7 +72,6 @@ resource "anypoint_apim_policy_basic_auth" "policy02" {
 - `audit` (Map of String) The instance's auditing data
 - `id` (String) The policy's unique id
 - `master_organization_id` (String) The organization id where the api instance is defined.
-- `order` (Number) The policy order.
 - `policy_template_id` (String) The policy template id
 
 <a id="nestedblock--configuration_data"></a>

--- a/docs/resources/apim_policy_client_id_enforcement.md
+++ b/docs/resources/apim_policy_client_id_enforcement.md
@@ -64,6 +64,7 @@ resource "anypoint_apim_policy_client_id_enforcement" "policy02" {
 - `asset_version` (String) the policy template version in anypoint exchange.
 - `disabled` (Boolean) Whether the policy is disabled.
 - `last_updated` (String) The last time this resource has been updated locally.
+- `order` (Number) The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.
 - `pointcut_data` (Block List) The Method & resource conditions (see [below for nested schema](#nestedblock--pointcut_data))
 
 ### Read-Only
@@ -71,7 +72,6 @@ resource "anypoint_apim_policy_client_id_enforcement" "policy02" {
 - `audit` (Map of String) The instance's auditing data
 - `id` (String) The policy's unique id
 - `master_organization_id` (String) The organization id where the api instance is defined.
-- `order` (Number) The policy order.
 - `policy_template_id` (String) The policy template id
 
 <a id="nestedblock--configuration_data"></a>

--- a/docs/resources/apim_policy_custom.md
+++ b/docs/resources/apim_policy_custom.md
@@ -212,6 +212,7 @@ resource "anypoint_apim_policy_custom" "policy_custom_06_outbound_obo" {
 - `disabled` (Boolean) Whether the policy is disabled.
 - `injection_point` (String) Where the policy is applied. 'inbound' (default) creates the policy via `POST .../policies`; 'outbound' creates it via `POST .../xapi/v1/.../policies/outbound-policies` and requires `upstream_id`. Required for credential-injection and LLM-provider policies that are outbound-only.
 - `last_updated` (String) The last time this resource has been updated locally.
+- `order` (Number) The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH. For outbound policies the value is applied via a follow-up PATCH after Create — the outbound POST endpoint does not accept `order` in its body.
 - `pointcut_data` (Block List) The method & resource conditions (see [below for nested schema](#nestedblock--pointcut_data))
 - `upstream_id` (String) Identifier of the upstream this outbound policy is bound to. Required when `injection_point = "outbound"` and must be left empty for inbound policies. Reference an `anypoint_api_instance_upstream.<x>.id`.
 
@@ -220,7 +221,6 @@ resource "anypoint_apim_policy_custom" "policy_custom_06_outbound_obo" {
 - `audit` (Map of String) The instance's auditing data
 - `id` (String) The policy's unique id
 - `master_organization_id` (String) The organization id where the api instance is defined.
-- `order` (Number) The policy order.
 - `policy_template_id` (String) The policy template id
 
 <a id="nestedblock--pointcut_data"></a>

--- a/docs/resources/apim_policy_jwt_validation.md
+++ b/docs/resources/apim_policy_jwt_validation.md
@@ -71,6 +71,7 @@ resource "anypoint_apim_policy_jwt_validation" "policy02" {
 - `asset_version` (String) the policy template version in anypoint exchange.
 - `disabled` (Boolean) Whether the policy is disabled.
 - `last_updated` (String) The last time this resource has been updated locally.
+- `order` (Number) The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.
 - `pointcut_data` (Block List) The Method & resource conditions (see [below for nested schema](#nestedblock--pointcut_data))
 
 ### Read-Only
@@ -78,7 +79,6 @@ resource "anypoint_apim_policy_jwt_validation" "policy02" {
 - `audit` (Map of String) The instance's auditing data
 - `id` (String) The policy's unique id
 - `master_organization_id` (String) The organization id where the api instance is defined.
-- `order` (Number) The policy order.
 - `policy_template_id` (String) The policy template id
 
 <a id="nestedblock--configuration_data"></a>

--- a/docs/resources/apim_policy_message_logging.md
+++ b/docs/resources/apim_policy_message_logging.md
@@ -84,6 +84,7 @@ resource "anypoint_apim_policy_message_logging" "policy02" {
 - `asset_version` (String) the policy template version in anypoint exchange.
 - `disabled` (Boolean) Whether the policy is disabled.
 - `last_updated` (String) The last time this resource has been updated locally.
+- `order` (Number) The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.
 - `pointcut_data` (Block List) The Method & resource conditions (see [below for nested schema](#nestedblock--pointcut_data))
 
 ### Read-Only
@@ -91,7 +92,6 @@ resource "anypoint_apim_policy_message_logging" "policy02" {
 - `audit` (Map of String) The instance's auditing data
 - `id` (String) The policy's unique id
 - `master_organization_id` (String) The organization id where the api instance is defined.
-- `order` (Number) The policy order.
 - `policy_template_id` (String) The policy template id
 
 <a id="nestedblock--configuration_data"></a>

--- a/docs/resources/apim_policy_rate_limiting.md
+++ b/docs/resources/apim_policy_rate_limiting.md
@@ -78,6 +78,7 @@ resource "anypoint_apim_policy_rate_limiting" "policy02" {
 - `asset_version` (String) the policy template version in anypoint exchange.
 - `disabled` (Boolean) Whether the policy is disabled.
 - `last_updated` (String) The last time this resource has been updated locally.
+- `order` (Number) The policy execution order. Lower values execute earlier. Leave unset to let Anypoint append at the end of the stack. Updating this value reorders the policy in place via PATCH.
 - `pointcut_data` (Block List) The Method & resource conditions (see [below for nested schema](#nestedblock--pointcut_data))
 
 ### Read-Only
@@ -85,7 +86,6 @@ resource "anypoint_apim_policy_rate_limiting" "policy02" {
 - `audit` (Map of String) The instance's auditing data
 - `id` (String) The policy's unique id
 - `master_organization_id` (String) The organization id where the api instance is defined.
-- `order` (Number) The policy order.
 - `policy_template_id` (String) The policy template id
 
 <a id="nestedblock--configuration_data"></a>


### PR DESCRIPTION
## Summary

- Promote `order` from `Computed` to `Optional + Computed` on all six `apim_policy_*` resources (`basic_auth`, `client_id_enforcement`, `jwt_validation`, `message_logging`, `rate_limit`, `custom`).
- Wire `order` into the inbound Create POST body and the PATCH Update body so users can declare execution position and reorder in place.
- For outbound `apim_policy_custom`, the value is applied via a follow-up `PATCH` after Create (the `POST .../outbound-policies` endpoint does not accept `order` in its body).

Closes v1.11.0 P0 row #7 (`policy_stack` ordering helper) from `docs/v1.11.0/`.

## Scope & rationale

Before this change, `order` was returned by the API on Read and surfaced as a `Computed` value, but Terraform configurations had no way to influence it — policies landed in whatever position the API assigned at Create time. That made declarative policy stack composition impossible: users either accepted creation-time ordering or had to reorder out-of-band in the API Manager UI.

Anypoint's `ApimPolicyBody.order` is already part of the published spec (inbound POST body) and the `PatchApimPolicy` endpoint accepts arbitrary body fields, so no spec patch or client-module release was required — this is a provider-only change.

Considered and rejected:

| Option | Why rejected |
|---|---|
| New composite `anypoint_apim_policy_stack` resource owning the full ordered set | Fights existing per-policy resources; forces a migration; doc divergence. The competitor (`mulesoft/anypoint`) uses the same per-policy `order` attribute shape we're shipping here. |
| Plan-time `data.anypoint_apim_policy_order` helper to detect duplicate-order config across siblings | SDK v2 `CustomizeDiff` cannot see sibling resource diffs, so the check would be cosmetic at best. Duplicate-order surfaces today as an API 400 at apply, which is fine for a user config bug. |

## Verification

Playground (`make install` → real Anypoint APIs in `aa1f55d6.../7074fcdd...`):

| Scenario | Result |
|---|---|
| Create `client_id_enforcement` with `order = 1`, `basic_auth` with `order = 3` | Both POST 201; state reflects declared order |
| `terraform plan` (no changes) on order attributes | No drift (separate pre-existing #144 password drift on basic_auth not related) |
| Change `client_id_enforcement.order` from `1 -> 5` | Plan shows `~ order` in-place; PATCH 200; output value = 5 |
| `terraform destroy` | All resources destroyed cleanly |

Outbound follow-up PATCH path is wired but not exercised end-to-end in playground (outbound smoke covered in PR #141); inbound path covered above.

## Test plan

- [x] `go build ./...`
- [x] `tfplugindocs generate` regenerated all six policy resource pages
- [x] Playground: Create with explicit `order` lands at declared position
- [x] Playground: Reorder via `terraform apply` PATCHes in place — no resource replacement
- [x] Playground: `terraform destroy` cleans up
- [x] `grep -n "replace " go.mod` clean