### PR TITLE
fix(private_space): add missing sa-east-1 and us-west-1 to network_region enum

### DIFF
--- a/anypoint/resource_private_space.go
+++ b/anypoint/resource_private_space.go
@@ -37,8 +37,9 @@ func preparePrivateSpaceResourceSchema() map[string]*schema.Schema {
 		ForceNew: true,
 		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
 			[]string{
-				"us-east-1", "us-east-2", "us-west-2", "ca-central-1", "eu-west-1", "eu-west-2",
-				"ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "eu-central-1",
+				"us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "sa-east-1",
+				"eu-west-1", "eu-west-2", "eu-central-1",
+				"ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
 			},
 			false,
 		)),


### PR DESCRIPTION
CloudHub 2.0 officially supports São Paulo (`sa-east-1`) and N. California (`us-west-1`) — see [CloudHub 2.0 Architecture / supported regions](https://docs.mulesoft.com/cloudhub-2/ch2-architecture). Both regions are already accepted by the `cloudhub2 shared space` deployment target enum in this provider (`cloudhub-sa-east-1`, `cloudhub-us-west-1`), but the `anypoint_private_space.network_region` client-side validator rejects them.

Today, a private space created in São Paulo via the Anypoint UI can be imported and managed, but the provider cannot **create** one there: the validator blocks `sa-east-1` even though the API accepts it (we run a private space in `sa-east-1` provisioned through the platform).

This PR adds the two missing regions to the `StringInSlice` validator. No API/client changes needed — validation is client-side only.

- `go build ./...` passes
- `gofmt` clean