### PR TITLE
fix(ai_gateway): nested-object schema for deny_topics + supported_vendors

### DIFF
--- a/anypoint/ai_gateway_resolve.go
+++ b/anypoint/ai_gateway_resolve.go
@@ -164,11 +164,20 @@ func aiGatewayGuardPolicy(d aiGatewayResourceLike, versions map[string]string) *
 			conf["threshold"] = v
 		}
 		if v, ok := sub["deny_topics"].([]any); ok && len(v) > 0 {
-			topics := make([]string, 0, len(v))
+			topics := make([]map[string]any, 0, len(v))
 			for _, t := range v {
-				if s, ok := t.(string); ok {
-					topics = append(topics, s)
+				m, ok := t.(map[string]any)
+				if !ok {
+					continue
 				}
+				entry := map[string]any{}
+				if s, _ := m["name"].(string); s != "" {
+					entry["name"] = s
+				}
+				if s, _ := m["embeddings"].(string); s != "" {
+					entry["embeddings"] = s
+				}
+				topics = append(topics, entry)
 			}
 			conf["denyTopics"] = topics
 		}
@@ -206,11 +215,20 @@ func aiGatewayRoutingPolicy(d aiGatewayResourceLike, versions map[string]string)
 		}
 		conf := map[string]any{}
 		if v, ok := sub["supported_vendors"].([]any); ok && len(v) > 0 {
-			vendors := make([]string, 0, len(v))
+			vendors := make([]map[string]any, 0, len(v))
 			for _, e := range v {
-				if s, ok := e.(string); ok {
-					vendors = append(vendors, s)
+				m, ok := e.(map[string]any)
+				if !ok {
+					continue
 				}
+				entry := map[string]any{}
+				if s, _ := m["vendor"].(string); s != "" {
+					entry["vendor"] = s
+				}
+				if s, _ := m["target_model"].(string); s != "" {
+					entry["targetModel"] = s
+				}
+				vendors = append(vendors, entry)
 			}
 			conf["supportedVendors"] = vendors
 		}

--- a/anypoint/ai_gateway_schema.go
+++ b/anypoint/ai_gateway_schema.go
@@ -124,7 +124,17 @@ func aiGatewayPromptGuardSchema() map[string]*schema.Schema {
 					"openai_embedding_model": {Type: schema.TypeString, Required: true, Description: "OpenAI embedding model identifier (`openaiEmbeddingModel`)."},
 					"openai_provider":        {Type: schema.TypeString, Optional: true, Description: "Optional OpenAI provider override (`openaiProvider`)."},
 					"threshold":              {Type: schema.TypeFloat, Required: true, Description: "Cosine-similarity threshold (`threshold`) above which a prompt is blocked."},
-					"deny_topics":            {Type: schema.TypeList, Required: true, Elem: &schema.Schema{Type: schema.TypeString}, Description: "List of denied topics (`denyTopics`)."},
+					"deny_topics": {
+						Type:        schema.TypeList,
+						Required:    true,
+						Description: "List of denied topics (`denyTopics`). Each entry pairs a topic name with its pre-computed embedding JSON string.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name":       {Type: schema.TypeString, Required: true, Description: "Topic name (`name`), e.g. `Politics`, `Violence`."},
+								"embeddings": {Type: schema.TypeString, Required: true, Sensitive: true, Description: "Pre-computed embedding vectors for the topic's example utterances, as a JSON string (`embeddings`)."},
+							},
+						},
+					},
 					"timeout":                {Type: schema.TypeInt, Optional: true, Description: "Timeout in milliseconds (`timeout`)."},
 				},
 			},
@@ -147,7 +157,17 @@ func aiGatewayRoutingSchema() map[string]*schema.Schema {
 			Description: "Configuration for the `model-based-routing` policy.",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"supported_vendors": {Type: schema.TypeList, Required: true, Elem: &schema.Schema{Type: schema.TypeString}, Description: "List of supported provider vendors (`supportedVendors`). Routing decides upstream based on the inbound `model` field matching one of these."},
+					"supported_vendors": {
+						Type:        schema.TypeList,
+						Required:    true,
+						Description: "List of supported provider vendors (`supportedVendors`). Routing decides upstream based on the inbound `model` field matching one of these.",
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"vendor":       {Type: schema.TypeString, Required: true, Description: "LLM vendor name (`vendor`), e.g. `Openai`, `Gemini`, `AzureOpenAI`."},
+								"target_model": {Type: schema.TypeString, Optional: true, Description: "Optional target model from the vendor (`targetModel`), e.g. `gpt-4`, `gemini-pro`."},
+							},
+						},
+					},
 					"fallback":          {Type: schema.TypeString, Optional: true, Description: "Optional fallback target identifier (`fallback`) when no rule matches."},
 				},
 			},

--- a/docs/resources/ai_gateway.md
+++ b/docs/resources/ai_gateway.md
@@ -72,14 +72,27 @@ resource "anypoint_ai_gateway" "prod" {
       openai_api_key         = var.openai_api_key
       openai_embedding_model = "text-embedding-3-small"
       threshold              = 0.85
-      deny_topics            = ["harm", "illegal", "violence"]
+      deny_topics {
+        name       = "Politics"
+        embeddings = var.politics_embeddings_json
+      }
+      deny_topics {
+        name       = "Violence"
+        embeddings = var.violence_embeddings_json
+      }
     }
   }
 
   routing {
     type = "model-based"
     model_based {
-      supported_vendors = ["anthropic", "openai"]
+      supported_vendors {
+        vendor       = "Openai"
+        target_model = "gpt-4"
+      }
+      supported_vendors {
+        vendor = "AzureOpenAI"
+      }
     }
   }
 
@@ -190,7 +203,7 @@ Required:
 
 Required:
 
-- `deny_topics` (List of String) List of denied topics (`denyTopics`).
+- `deny_topics` (Block List, Min: 1) List of denied topics (`denyTopics`). Each entry pairs a topic name with its pre-computed embedding JSON string. (see [below for nested schema](#nestedblock--prompt_guard--semantic_openai--deny_topics))
 - `openai_api_key` (String, Sensitive) OpenAI API key (`openaiApiKey`).
 - `openai_embedding_model` (String) OpenAI embedding model identifier (`openaiEmbeddingModel`).
 - `openai_url` (String) OpenAI embeddings endpoint URL (`openaiUrl`).
@@ -200,6 +213,15 @@ Optional:
 
 - `openai_provider` (String) Optional OpenAI provider override (`openaiProvider`).
 - `timeout` (Number) Timeout in milliseconds (`timeout`).
+
+<a id="nestedblock--prompt_guard--semantic_openai--deny_topics"></a>
+### Nested Schema for `prompt_guard.semantic_openai.deny_topics`
+
+Required:
+
+- `embeddings` (String, Sensitive) Pre-computed embedding vectors for the topic's example utterances, as a JSON string (`embeddings`).
+- `name` (String) Topic name (`name`), e.g. `Politics`, `Violence`.
+
 
 
 
@@ -239,11 +261,23 @@ Required:
 
 Required:
 
-- `supported_vendors` (List of String) List of supported provider vendors (`supportedVendors`). Routing decides upstream based on the inbound `model` field matching one of these.
+- `supported_vendors` (Block List, Min: 1) List of supported provider vendors (`supportedVendors`). Routing decides upstream based on the inbound `model` field matching one of these. (see [below for nested schema](#nestedblock--routing--model_based--supported_vendors))
 
 Optional:
 
 - `fallback` (String) Optional fallback target identifier (`fallback`) when no rule matches.
+
+<a id="nestedblock--routing--model_based--supported_vendors"></a>
+### Nested Schema for `routing.model_based.supported_vendors`
+
+Required:
+
+- `vendor` (String) LLM vendor name (`vendor`), e.g. `Openai`, `Gemini`, `AzureOpenAI`.
+
+Optional:
+
+- `target_model` (String) Optional target model from the vendor (`targetModel`), e.g. `gpt-4`, `gemini-pro`.
+
 
 
 

--- a/examples/resources/anypoint_ai_gateway/resource.tf
+++ b/examples/resources/anypoint_ai_gateway/resource.tf
@@ -37,14 +37,27 @@ resource "anypoint_ai_gateway" "prod" {
       openai_api_key         = var.openai_api_key
       openai_embedding_model = "text-embedding-3-small"
       threshold              = 0.85
-      deny_topics            = ["harm", "illegal", "violence"]
+      deny_topics {
+        name       = "Politics"
+        embeddings = var.politics_embeddings_json
+      }
+      deny_topics {
+        name       = "Violence"
+        embeddings = var.violence_embeddings_json
+      }
     }
   }
 
   routing {
     type = "model-based"
     model_based {
-      supported_vendors = ["anthropic", "openai"]
+      supported_vendors {
+        vendor       = "Openai"
+        target_model = "gpt-4"
+      }
+      supported_vendors {
+        vendor = "AzureOpenAI"
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- `prompt_guard.semantic_openai.deny_topics`: was `[]string`, now nested block `{name, embeddings}` matching the `denyTopics` API shape.
- `routing.model_based.supported_vendors`: was `[]string`, now nested block `{vendor, target_model}` matching the `supportedVendors` API shape.
- Resolver emits `[]map[string]any` for both.

## Affected modules

`anypoint/ai_gateway_schema.go`, `anypoint/ai_gateway_resolve.go`, examples, docs.

## Related

Closes #154

## Type of change

- [x] Bug fix