### PR TITLE
chore(release): bump VERSION to 1.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=anypoint.mulesoft.com
 NAMESPACE=automation
 NAME=anypoint
 BINARY=terraform-provider-${NAME}
-VERSION=1.11.0-SNAPSHOT
+VERSION=1.11.0
 OS_ARCH=darwin_arm64
 
 default: install


### PR DESCRIPTION
## Summary

- Bumps `Makefile` VERSION `1.11.0-SNAPSHOT` → `1.11.0`.

## Related

- Milestone: v1.11.0
- Release PR (dev → master): follow-up.

## Type of change

- [x] Dependency / client module bump (Makefile VERSION only)