### PR TITLE
fix(private_space): stop sending reserved CIDRs on update

### DIFF
--- a/anypoint/resource_private_space.go
+++ b/anypoint/resource_private_space.go
@@ -88,7 +88,8 @@ func preparePrivateSpaceResourceSchema() map[string]*schema.Schema {
 	ps_schema["network_reserved_cidrs"] = &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
-		Description: "Reserved CIDR blocks.",
+		ForceNew:    true,
+		Description: "Reserved CIDR blocks. Can only be set at creation time; the Anypoint API rejects updates to this field once the network is created, so changing it forces a new private space.",
 		Elem: &schema.Schema{
 			Type:             schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.IsCIDR),
@@ -409,14 +410,10 @@ func newPrivateSpacePatchBody(d *schema.ResourceData) *private_space.PrivateSpac
 		network.SetInternalDns(*networkDnsServers)
 		networkUpdated = true
 	}
-	if network_reserved_cidrs := d.Get("network_reserved_cidrs").([]any); len(network_reserved_cidrs) > 0 {
-		var reservedCIDRs []string
-		for _, cidr := range network_reserved_cidrs {
-			reservedCIDRs = append(reservedCIDRs, cidr.(string))
-		}
-		network.SetReservedCidrs(reservedCIDRs)
-		networkUpdated = true
-	}
+	// network_reserved_cidrs is intentionally omitted from the patch body: the
+	// Anypoint API rejects any reservedCidrs in an update ("Reserved CIDR's cannot
+	// be updated once the network is created", HTTP 400). The field is ForceNew, so
+	// a change recreates the private space instead of patching it.
 	if firewall := d.Get("firewall_rules").([]any); len(firewall) > 0 {
 		var rules []private_space.FirewallRule
 		for _, rule := range firewall {
@@ -457,7 +454,6 @@ func updatablePrivateSpaceAttributes() []string {
 		"environments_business_groups",
 		"network_internal_dns_servers",
 		"network_internal_dns_special_domains",
-		"network_reserved_cidrs",
 		"firewall_rules",
 		"enable_iam_role",
 		"enable_egress",

--- a/docs/resources/private_space.md
+++ b/docs/resources/private_space.md
@@ -85,7 +85,7 @@ resource "anypoint_private_space" "my_ps" {
 - `firewall_rules` (Block List) Firewall rules for the private space. (see [below for nested schema](#nestedblock--firewall_rules))
 - `network_internal_dns_servers` (List of String) List of DNS servers. Values should be valid IP addresses (v4 or v6)
 - `network_internal_dns_special_domains` (List of String) List of domains to be used for internal DNS resolution.
-- `network_reserved_cidrs` (List of String) Reserved CIDR blocks.
+- `network_reserved_cidrs` (List of String) Reserved CIDR blocks. Can only be set at creation time; the Anypoint API rejects updates to this field once the network is created, so changing it forces a new private space.
 
 ### Read-Only
 


### PR DESCRIPTION
## Summary

- Stop sending `network_reserved_cidrs` in the private space PATCH body. The Anypoint API rejects any `reservedCidrs` on update (`HTTP 400 "Reserved CIDR's cannot be updated once the network is created"`), so every update — including the create-completion update and updates to unrelated fields — failed once the network existed. `lifecycle.ignore_changes` didn't help: the value stays in state and the patch was built from state.
- Mark `network_reserved_cidrs` as `ForceNew` — recreation is the only way to change a reserved CIDR. Creation still sends it via the POST body.

## Related

- Closes: #162

## Type of change

- [x] Bug fix in existing resource / data source

## Checklist

- [x] `gofmt`/`goimports` clean, `make build` passes.
- [x] Immutable field marked `ForceNew: true`.
- [x] No `replace` directive in `go.mod` (no spec/client change required).
- [x] `tfplugindocs generate` ran; `docs/` committed.
- [x] Playground verified against real API: create + update (firewall change with reserved CIDR in state) succeed; reserved CIDR change forces replacement; `terraform destroy` clean.
