### PR TITLE
ci: release pipeline (GoReleaser build/sign + Discord announce)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# When a GitHub release is published, build + sign the provider binaries for
+# that tag with GoReleaser, upload them to the release, then announce the
+# release notes on Discord.
+#
+# Required repository secrets:
+#   GPG_PRIVATE_KEY  - ASCII-armored private key registered on the Terraform
+#                      registry (gpg --armor --export-secret-key <fingerprint>)
+#   GPG_PASSPHRASE   - passphrase for that key
+#   DISCORD_WEBHOOK  - channel webhook URL (optional; Discord step no-ops if unset)
+# GITHUB_TOKEN is provided automatically.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Stage release notes
+        env:
+          BODY: ${{ github.event.release.body }}
+        run: printf '%s' "$BODY" > release-notes.md
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean --release-notes release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.gpg.outputs.fingerprint }}
+
+      - name: Announce on Discord
+        if: ${{ !github.event.release.prerelease }}
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          TAG: ${{ github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+          BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "DISCORD_WEBHOOK secret not set — skipping Discord announce."
+            exit 0
+          fi
+          # Discord embed description caps at 4096 chars; leave headroom.
+          desc=$(printf '%s' "$BODY" | head -c 3800)
+          if [ "$(printf '%s' "$BODY" | wc -c)" -gt 3800 ]; then
+            desc="${desc}"$'\n\n…full notes → '"$URL"
+          fi
+          payload=$(jq -n \
+            --arg title "terraform-provider-anypoint ${TAG}" \
+            --arg url   "$URL" \
+            --arg desc  "$desc" \
+            '{
+              username: "Anypoint Provider Releases",
+              embeds: [{ title: $title, url: $url, description: $desc, color: 41183 }]
+            }')
+          code=$(curl -sS -o /tmp/discord_resp -w '%{http_code}' \
+            -H "Content-Type: application/json" \
+            -d "$payload" "$WEBHOOK")
+          echo "Discord responded: HTTP $code"
+          cat /tmp/discord_resp || true
+          [ "$code" = "204" ]

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ docs/v*/
 # Claude Code: ignore personal config, keep shared commands tracked
 .claude/*
 !.claude/commands/
+
+# CI release: notes staged from the GitHub release body at runtime
+release-notes.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,5 +53,7 @@ signs:
 release:
   # If you want to manually examine the release before its live, use true on this line:
   draft: false
+  # Re-running the pipeline against an existing release replaces assets instead of erroring.
+  replace_existing_artifacts: true
 changelog:
   disable: true


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` — on a **published** GitHub release, GoReleaser builds + GPG-signs the provider binaries for the tag, uploads them to that release (using the release body as notes), then posts the notes to Discord.
- Moves the previously-local `goreleaser release` flow into CI. You keep creating the release (with notes) on GitHub; CI does the build/sign/upload/announce.
- `.goreleaser.yml`: `replace_existing_artifacts: true` so re-running against an existing release doesn't fail on duplicate assets.

## Flow

1. Tag + create a GitHub release with your notes (publish it).
2. CI checks out the tag, imports the signing key, runs `goreleaser release --release-notes <body>` → 14 platform zips + `SHA256SUMS` + `.sig` uploaded to the release.
3. Discord step posts the notes (skipped for prereleases; no-ops if `DISCORD_WEBHOOK` unset).

## Required secrets (one-time)

| Secret | Value |
|---|---|
| `GPG_PRIVATE_KEY` | `gpg --armor --export-secret-key <fingerprint>` of the registry signing key (the one that signed prior releases) |
| `GPG_PASSPHRASE` | passphrase for that key |
| `DISCORD_WEBHOOK` | Discord channel webhook URL (optional) |

`GITHUB_TOKEN` is automatic.

## Notes

- Trigger is `release: published`. If you'd rather have GoReleaser create the release itself on tag push, that's a one-line trigger swap — say the word.
- Uses the standard `goreleaser/goreleaser-action` + `crazy-max/ghaction-import-gpg` (HashiCorp's documented provider-release setup). Can pin to commit SHAs instead of tags if you want stricter supply-chain hardening.

## Type of change

- [x] CI / tooling
