### PR TITLE
Release v1.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=anypoint.mulesoft.com
 NAMESPACE=automation
 NAME=anypoint
 BINARY=terraform-provider-${NAME}
-VERSION=1.11.1
+VERSION=1.11.2
 OS_ARCH=darwin_arm64
 
 default: install

--- a/anypoint/resource_private_space.go
+++ b/anypoint/resource_private_space.go
@@ -102,18 +102,21 @@ func preparePrivateSpaceResourceSchema() map[string]*schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"cidr_block": {
-					Type:             schema.TypeString,
-					Required:         true,
-					ValidateDiagFunc: validation.ToDiagFunc(validation.IsCIDR),
-					Description:      "The CIDR block for the firewall rule.",
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateDiagFunc: validation.ToDiagFunc(validation.Any(
+						validation.IsCIDR,
+						validation.StringInSlice([]string{"local-private-network"}, false),
+					)),
+					Description: "The source/destination for the firewall rule. Either a CIDR block or the special value 'local-private-network'.",
 				},
 				"protocol": {
 					Type:     schema.TypeString,
 					Required: true,
 					ValidateDiagFunc: validation.ToDiagFunc(
-						validation.StringInSlice([]string{"tcp", "udp", "icmp"}, false),
+						validation.StringInSlice([]string{"tcp", "udp", "icmp", "all"}, false),
 					),
-					Description: "Specifies the network protocol used in the firewall rule. Valid options are 'tcp', 'udp', or 'icmp'.",
+					Description: "Specifies the network protocol used in the firewall rule. Valid options are 'tcp', 'udp', 'icmp', or 'all'.",
 				},
 				"from_port": {
 					Type:             schema.TypeInt,

--- a/docs/resources/private_space.md
+++ b/docs/resources/private_space.md
@@ -110,9 +110,9 @@ resource "anypoint_private_space" "my_ps" {
 
 Required:
 
-- `cidr_block` (String) The CIDR block for the firewall rule.
+- `cidr_block` (String) The source/destination for the firewall rule. Either a CIDR block or the special value 'local-private-network'.
 - `from_port` (Number) The starting port for the firewall rule.
-- `protocol` (String) Specifies the network protocol used in the firewall rule. Valid options are 'tcp', 'udp', or 'icmp'.
+- `protocol` (String) Specifies the network protocol used in the firewall rule. Valid options are 'tcp', 'udp', 'icmp', or 'all'.
 - `to_port` (Number) The ending port for the firewall rule.
 - `type` (String) The type of the firewall rule. Valid values are 'inbound' for incoming traffic and 'outbound' for outgoing traffic.
 


### PR DESCRIPTION
## What's Changed

Patch release. Fixes over-strict plan-time validation on `anypoint_private_space` firewall rules. No new resources, no breaking changes — safe upgrade from any `1.11.x`.

## 🐛 Bug Fixes

- **`anypoint_private_space`** — Firewall rule `cidr_block` now accepts the special value `local-private-network` alongside CIDR notation, and `protocol` accepts `all` in addition to `tcp`/`udp`/`icmp`. Previously the schema rejected both at plan/validate time even though the platform supports them (`local-private-network` source/destination, and `all` protocol on outbound rules). The schema stays permissive; the API enforces the inbound/outbound direction constraint (`all` is outbound-only).
  — PR: #167 • Issue: #166

## ✅ Compatibility

No breaking changes. Safe patch upgrade from `1.11.x`.

## Next steps

- Tag `v1.11.2` after this merge.
- Publish GitHub release.
