### PR TITLE
fix(build): require Go 1.21 for release pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mulesoft-anypoint/terraform-provider-anypoint
 
-go 1.20
+go 1.21
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0


### PR DESCRIPTION
## What

Bumps the `go.mod` directive `go 1.20` → `go 1.21`.

## Why

The `anypoint` package imports the stdlib `maps` package (added in Go 1.21), but `go.mod` declared `go 1.20`. Local builds pass on newer toolchains, so this went unnoticed. The new release pipeline's `setup-go` honors `go-version-file: go.mod`, installed Go 1.20.14, and GoReleaser failed:

```
anypoint/data_source_apim.go:5:2: package maps is not in GOROOT (/opt/hostedtoolcache/go/1.20.14/x64/src/maps)
```

1.21 is the true minimum this codebase compiles against. Unblocks the v1.11.2 release build.

## Compatibility

No breaking changes.